### PR TITLE
Review Python SDK for latest changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2025-12-31
+
+### Added - Python SDK v0.1.18 Feature Parity
+
+#### File Checkpointing & Rewind (v0.1.15+)
+- `enable_file_checkpointing` option in `ClaudeAgentOptions` for enabling file state checkpointing
+- `rewind_files(user_message_uuid)` method on `Query` and `Client` classes
+- `uuid` field on `UserMessage` for tracking message identifiers for rewind support
+
+#### Beta Features Support (v0.1.12+)
+- `SDK_BETAS` constant with available beta features (e.g., `"context-1m-2025-08-07"`)
+- `betas` option in `ClaudeAgentOptions` for enabling beta features
+
+#### Tools Configuration (v0.1.12+)
+- `tools` option for base tools selection (separate from `allowed_tools`)
+- Supports array of tool names, empty array `[]`, or `ToolsPreset` object
+- `ToolsPreset` class for preset-based tool configuration
+- `append_allowed_tools` option to append tools to the allowed list
+
+#### Sandbox Settings (v0.1.11+)
+- `SandboxSettings` class for isolated command execution configuration
+- `SandboxNetworkConfig` class for network isolation settings
+- `SandboxIgnoreViolations` class for configuring violation handling
+- `sandbox` option in `ClaudeAgentOptions` for sandbox configuration
+- Automatic merging of sandbox settings into the main settings JSON
+
+#### Additional Types
+- `SystemPromptPreset` class for preset-based system prompts
+
+### Technical Details
+- All new CLI flags properly passed to Claude Code subprocess
+- Sandbox settings merged into `--settings` JSON for CLI compatibility
+- UserMessage UUID parsed from CLI output for rewind support
+
 ## [0.2.0] - 2025-10-17
 
 ### Changed

--- a/lib/claude_agent_sdk.rb
+++ b/lib/claude_agent_sdk.rb
@@ -244,6 +244,15 @@ module ClaudeAgentSDK
       @query_handler.set_model(model)
     end
 
+    # Rewind files to a previous checkpoint (v0.1.15+)
+    # Restores file state to what it was at the given user message
+    # Requires enable_file_checkpointing to be true in options
+    # @param user_message_uuid [String] The UUID of the UserMessage to rewind to
+    def rewind_files(user_message_uuid)
+      raise CLIConnectionError, 'Not connected. Call connect() first' unless @connected
+      @query_handler.rewind_files(user_message_uuid)
+    end
+
     # Get server initialization info
     # @return [Hash, nil] Server info or nil
     def server_info

--- a/lib/claude_agent_sdk/message_parser.rb
+++ b/lib/claude_agent_sdk/message_parser.rb
@@ -32,6 +32,7 @@ module ClaudeAgentSDK
 
     def self.parse_user_message(data)
       parent_tool_use_id = data[:parent_tool_use_id]
+      uuid = data[:uuid] # UUID for rewind support (v0.1.17+)
       message_data = data[:message]
       raise MessageParseError.new("Missing message field in user message", data: data) unless message_data
 
@@ -40,9 +41,9 @@ module ClaudeAgentSDK
 
       if content.is_a?(Array)
         content_blocks = content.map { |block| parse_content_block(block) }
-        UserMessage.new(content: content_blocks, parent_tool_use_id: parent_tool_use_id)
+        UserMessage.new(content: content_blocks, uuid: uuid, parent_tool_use_id: parent_tool_use_id)
       else
-        UserMessage.new(content: content, parent_tool_use_id: parent_tool_use_id)
+        UserMessage.new(content: content, uuid: uuid, parent_tool_use_id: parent_tool_use_id)
       end
     end
 

--- a/lib/claude_agent_sdk/query.rb
+++ b/lib/claude_agent_sdk/query.rb
@@ -551,6 +551,17 @@ module ClaudeAgentSDK
                            })
     end
 
+    # Rewind files to a previous checkpoint (v0.1.15+)
+    # Restores file state to what it was at the given user message
+    # Requires enable_file_checkpointing to be true in options
+    # @param user_message_uuid [String] The UUID of the UserMessage to rewind to
+    def rewind_files(user_message_uuid)
+      send_control_request({
+                             subtype: 'rewind_files',
+                             userMessageUuid: user_message_uuid
+                           })
+    end
+
     # Stream input messages to transport
     def stream_input(stream)
       stream.each do |message|

--- a/lib/claude_agent_sdk/version.rb
+++ b/lib/claude_agent_sdk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ClaudeAgentSDK
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 end


### PR DESCRIPTION
New features aligned with Python SDK:
- File checkpointing & rewind (v0.1.15+): enable_file_checkpointing option and rewind_files() method on Query and Client classes
- UserMessage.uuid field for rewind support (v0.1.17+)
- SDK betas support (v0.1.12+): betas option and SDK_BETAS constant
- Tools configuration (v0.1.12+): tools option, ToolsPreset class, append_allowed_tools option
- Sandbox settings (v0.1.11+): SandboxSettings, SandboxNetworkConfig, SandboxIgnoreViolations classes with sandbox option
- SystemPromptPreset class for preset-based system prompts

Updated CLI transport to pass new flags:
- --betas, --tools, --append-allowed-tools, --enable-file-checkpointing
- Sandbox settings merged into --settings JSON

Version bumped to 0.4.0