### PR TITLE
feat: sync Ruby SDK with Python SDK v0.1.46

### DIFF
--- a/lib/claude_agent_sdk.rb
+++ b/lib/claude_agent_sdk.rb
@@ -10,6 +10,7 @@ require_relative 'claude_agent_sdk/message_parser'
 require_relative 'claude_agent_sdk/query'
 require_relative 'claude_agent_sdk/sdk_mcp_server'
 require_relative 'claude_agent_sdk/streaming'
+require_relative 'claude_agent_sdk/sessions'
 require 'async'
 require 'securerandom'
 
@@ -58,6 +59,25 @@ module ClaudeAgentSDK
   #   ClaudeAgentSDK.query(prompt: messages) do |message|
   #     puts message
   #   end
+  # List sessions for a directory (or all sessions)
+  # @param directory [String, nil] Working directory to list sessions for
+  # @param limit [Integer, nil] Maximum number of sessions to return
+  # @param include_worktrees [Boolean] Whether to include git worktree sessions
+  # @return [Array<SDKSessionInfo>] Sessions sorted by last_modified descending
+  def self.list_sessions(directory: nil, limit: nil, include_worktrees: true)
+    Sessions.list_sessions(directory: directory, limit: limit, include_worktrees: include_worktrees)
+  end
+
+  # Get messages from a session transcript
+  # @param session_id [String] The session UUID
+  # @param directory [String, nil] Working directory to search in
+  # @param limit [Integer, nil] Maximum number of messages
+  # @param offset [Integer] Number of messages to skip
+  # @return [Array<SessionMessage>] Ordered messages from the session
+  def self.get_session_messages(session_id:, directory: nil, limit: nil, offset: 0)
+    Sessions.get_session_messages(session_id: session_id, directory: directory, limit: limit, offset: offset)
+  end
+
   def self.query(prompt:, options: nil, &block)
     return enum_for(:query, prompt: prompt, options: options) unless block
 

--- a/lib/claude_agent_sdk.rb
+++ b/lib/claude_agent_sdk.rb
@@ -310,6 +310,28 @@ module ClaudeAgentSDK
       @query_handler.set_model(model)
     end
 
+    # Reconnect a failed MCP server
+    # @param server_name [String] Name of the MCP server to reconnect
+    def reconnect_mcp_server(server_name)
+      raise CLIConnectionError, 'Not connected. Call connect() first' unless @connected
+      @query_handler.reconnect_mcp_server(server_name)
+    end
+
+    # Enable or disable an MCP server
+    # @param server_name [String] Name of the MCP server
+    # @param enabled [Boolean] Whether to enable or disable
+    def toggle_mcp_server(server_name, enabled)
+      raise CLIConnectionError, 'Not connected. Call connect() first' unless @connected
+      @query_handler.toggle_mcp_server(server_name, enabled)
+    end
+
+    # Stop a running background task
+    # @param task_id [String] The ID of the task to stop
+    def stop_task(task_id)
+      raise CLIConnectionError, 'Not connected. Call connect() first' unless @connected
+      @query_handler.stop_task(task_id)
+    end
+
     # Rewind files to a previous checkpoint (v0.1.15+)
     # Restores file state to what it was at the given user message
     # Requires enable_file_checkpointing to be true in options

--- a/lib/claude_agent_sdk/message_parser.rb
+++ b/lib/claude_agent_sdk/message_parser.rb
@@ -102,10 +102,11 @@ module ClaudeAgentSDK
         is_error: data[:is_error],
         num_turns: data[:num_turns],
         session_id: data[:session_id],
+        stop_reason: data[:stop_reason],
         total_cost_usd: data[:total_cost_usd],
         usage: data[:usage],
         result: data[:result],
-        structured_output: data[:structured_output] # Structured output when output_format is specified
+        structured_output: data[:structured_output]
       )
     end
 

--- a/lib/claude_agent_sdk/message_parser.rb
+++ b/lib/claude_agent_sdk/message_parser.rb
@@ -66,10 +66,32 @@ module ClaudeAgentSDK
     end
 
     def self.parse_system_message(data)
-      SystemMessage.new(
-        subtype: data[:subtype],
-        data: data
-      )
+      case data[:subtype]
+      when 'task_started'
+        TaskStartedMessage.new(
+          subtype: data[:subtype], data: data,
+          task_id: data[:task_id], description: data[:description],
+          uuid: data[:uuid], session_id: data[:session_id],
+          tool_use_id: data[:tool_use_id], task_type: data[:task_type]
+        )
+      when 'task_progress'
+        TaskProgressMessage.new(
+          subtype: data[:subtype], data: data,
+          task_id: data[:task_id], description: data[:description],
+          usage: data[:usage], uuid: data[:uuid], session_id: data[:session_id],
+          tool_use_id: data[:tool_use_id], last_tool_name: data[:last_tool_name]
+        )
+      when 'task_notification'
+        TaskNotificationMessage.new(
+          subtype: data[:subtype], data: data,
+          task_id: data[:task_id], status: data[:status],
+          output_file: data[:output_file], summary: data[:summary],
+          uuid: data[:uuid], session_id: data[:session_id],
+          tool_use_id: data[:tool_use_id], usage: data[:usage]
+        )
+      else
+        SystemMessage.new(subtype: data[:subtype], data: data)
+      end
     end
 
     def self.parse_result_message(data)

--- a/lib/claude_agent_sdk/query.rb
+++ b/lib/claude_agent_sdk/query.rb
@@ -316,13 +316,19 @@ module ClaudeAgentSDK
         permission_mode: fetch.call(:permission_mode)
       }
 
+      # Subagent context fields shared by tool-lifecycle hooks
+      subagent_args = {
+        agent_id: fetch.call(:agent_id),
+        agent_type: fetch.call(:agent_type)
+      }
+
       case event_name
       when 'PreToolUse'
         PreToolUseHookInput.new(
           tool_name: fetch.call(:tool_name),
           tool_input: fetch.call(:tool_input),
           tool_use_id: fetch.call(:tool_use_id),
-          **base_args
+          **subagent_args, **base_args
         )
       when 'PostToolUse'
         PostToolUseHookInput.new(
@@ -330,7 +336,7 @@ module ClaudeAgentSDK
           tool_input: fetch.call(:tool_input),
           tool_response: fetch.call(:tool_response),
           tool_use_id: fetch.call(:tool_use_id),
-          **base_args
+          **subagent_args, **base_args
         )
       when 'PostToolUseFailure'
         PostToolUseFailureHookInput.new(
@@ -339,7 +345,7 @@ module ClaudeAgentSDK
           tool_use_id: fetch.call(:tool_use_id),
           error: fetch.call(:error),
           is_interrupt: fetch.call(:is_interrupt),
-          **base_args
+          **subagent_args, **base_args
         )
       when 'UserPromptSubmit'
         UserPromptSubmitHookInput.new(
@@ -377,7 +383,7 @@ module ClaudeAgentSDK
           tool_name: fetch.call(:tool_name),
           tool_input: fetch.call(:tool_input),
           permission_suggestions: fetch.call(:permission_suggestions),
-          **base_args
+          **subagent_args, **base_args
         )
       when 'PreCompact'
         PreCompactHookInput.new(

--- a/lib/claude_agent_sdk/query.rb
+++ b/lib/claude_agent_sdk/query.rb
@@ -662,6 +662,35 @@ module ClaudeAgentSDK
                            })
     end
 
+    # Reconnect a failed MCP server
+    # @param server_name [String] Name of the MCP server to reconnect
+    def reconnect_mcp_server(server_name)
+      send_control_request({
+                             subtype: 'mcp_reconnect',
+                             serverName: server_name
+                           })
+    end
+
+    # Enable or disable an MCP server
+    # @param server_name [String] Name of the MCP server
+    # @param enabled [Boolean] Whether to enable or disable
+    def toggle_mcp_server(server_name, enabled)
+      send_control_request({
+                             subtype: 'mcp_toggle',
+                             serverName: server_name,
+                             enabled: enabled
+                           })
+    end
+
+    # Stop a running background task
+    # @param task_id [String] The ID of the task to stop
+    def stop_task(task_id)
+      send_control_request({
+                             subtype: 'stop_task',
+                             task_id: task_id
+                           })
+    end
+
     # Rewind files to a previous checkpoint (v0.1.15+)
     # Restores file state to what it was at the given user message
     # Requires enable_file_checkpointing to be true in options

--- a/lib/claude_agent_sdk/sessions.rb
+++ b/lib/claude_agent_sdk/sessions.rb
@@ -3,6 +3,7 @@
 require 'English'
 require 'json'
 require 'pathname'
+require 'shellwords'
 
 module ClaudeAgentSDK
   # Session info returned by list_sessions

--- a/lib/claude_agent_sdk/sessions.rb
+++ b/lib/claude_agent_sdk/sessions.rb
@@ -1,0 +1,493 @@
+# frozen_string_literal: true
+
+require 'English'
+require 'json'
+require 'pathname'
+
+module ClaudeAgentSDK
+  # Session info returned by list_sessions
+  class SDKSessionInfo
+    attr_accessor :session_id, :summary, :last_modified, :file_size,
+                  :custom_title, :first_prompt, :git_branch, :cwd
+
+    def initialize(session_id:, summary:, last_modified:, file_size:,
+                   custom_title: nil, first_prompt: nil, git_branch: nil, cwd: nil)
+      @session_id = session_id
+      @summary = summary
+      @last_modified = last_modified
+      @file_size = file_size
+      @custom_title = custom_title
+      @first_prompt = first_prompt
+      @git_branch = git_branch
+      @cwd = cwd
+    end
+  end
+
+  # A single message from a session transcript
+  class SessionMessage
+    attr_accessor :type, :uuid, :session_id, :message, :parent_tool_use_id
+
+    def initialize(type:, uuid:, session_id:, message:, parent_tool_use_id: nil)
+      @type = type
+      @uuid = uuid
+      @session_id = session_id
+      @message = message
+      @parent_tool_use_id = parent_tool_use_id
+    end
+  end
+
+  # Session browsing functions
+  module Sessions # rubocop:disable Metrics/ModuleLength
+    LITE_READ_BUF_SIZE = 65_536
+    MAX_SANITIZED_LENGTH = 200
+
+    UUID_RE = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
+
+    SKIP_FIRST_PROMPT_PATTERN = %r{\A(?:<local-command-stdout>|<session-start-hook>|<tick>|<goal>|
+      \[Request\ interrupted\ by\ user[^\]]*\]|
+      \s*<ide_opened_file>[\s\S]*</ide_opened_file>\s*\z|
+      \s*<ide_selection>[\s\S]*</ide_selection>\s*\z)}x
+
+    COMMAND_NAME_RE = %r{<command-name>(.*?)</command-name>}
+
+    SANITIZE_RE = /[^a-zA-Z0-9]/
+
+    module_function
+
+    # Match TypeScript's simpleHash: signed 32-bit integer, base-36 output
+    def simple_hash(str)
+      h = 0
+      str.each_char do |ch|
+        char_code = ch.ord
+        h = ((h << 5) - h + char_code) & 0xFFFFFFFF
+        h -= 0x100000000 if h >= 0x80000000
+      end
+      h = h.abs
+
+      return '0' if h.zero?
+
+      digits = '0123456789abcdefghijklmnopqrstuvwxyz'
+      out = []
+      n = h
+      while n.positive?
+        out.unshift(digits[n % 36])
+        n /= 36
+      end
+      out.join
+    end
+
+    # Sanitize a filesystem path to a project directory name
+    def sanitize_path(name)
+      sanitized = name.gsub(SANITIZE_RE, '-')
+      return sanitized if sanitized.length <= MAX_SANITIZED_LENGTH
+
+      "#{sanitized[0, MAX_SANITIZED_LENGTH]}-#{simple_hash(name)}"
+    end
+
+    # Get the Claude config directory
+    def config_dir
+      ENV.fetch('CLAUDE_CONFIG_DIR', File.expand_path('~/.claude'))
+    end
+
+    # Find the project directory for a given path
+    def find_project_dir(path)
+      projects_dir = File.join(config_dir, 'projects')
+      return nil unless File.directory?(projects_dir)
+
+      sanitized = sanitize_path(path)
+      exact_path = File.join(projects_dir, sanitized)
+      return exact_path if File.directory?(exact_path)
+
+      # For long paths, scan for prefix match
+      if sanitized.length > MAX_SANITIZED_LENGTH
+        prefix = sanitized[0, MAX_SANITIZED_LENGTH + 1] # includes the trailing '-'
+        Dir.children(projects_dir).each do |child|
+          candidate = File.join(projects_dir, child)
+          return candidate if File.directory?(candidate) && child.start_with?(prefix)
+        end
+      end
+
+      nil
+    end
+
+    # Extract a JSON string field value from raw text without full JSON parse
+    def extract_json_string_field(text, key, last: false)
+      search_patterns = ["\"#{key}\":\"", "\"#{key}\": \""]
+      result = nil
+
+      search_patterns.each do |pattern|
+        pos = 0
+        loop do
+          idx = text.index(pattern, pos)
+          break unless idx
+
+          value_start = idx + pattern.length
+          value = extract_json_string_value(text, value_start)
+          if value
+            result = unescape_json_string(value)
+            return result unless last
+          end
+          pos = value_start
+        end
+      end
+
+      result
+    end
+
+    # Extract string value starting at pos (handles escapes)
+    def extract_json_string_value(text, start)
+      pos = start
+      while pos < text.length
+        ch = text[pos]
+        if ch == '\\'
+          pos += 2
+        elsif ch == '"'
+          return text[start...pos]
+        else
+          pos += 1
+        end
+      end
+      nil
+    end
+
+    # Unescape a JSON string value
+    def unescape_json_string(str)
+      JSON.parse("\"#{str}\"")
+    rescue JSON::ParserError
+      str
+    end
+
+    # Extract the first meaningful user prompt from the head of a JSONL file
+    def extract_first_prompt_from_head(head)
+      command_fallback = nil
+
+      head.each_line do |line|
+        next unless line.include?('"type":"user"') || line.include?('"type": "user"')
+        next if line.include?('"tool_result"')
+        next if line.include?('"isMeta":true') || line.include?('"isMeta": true')
+        next if line.include?('"isCompactSummary":true') || line.include?('"isCompactSummary": true')
+
+        entry = JSON.parse(line, symbolize_names: false)
+        content = entry.dig('message', 'content')
+        next unless content
+
+        texts = if content.is_a?(String)
+                  [content]
+                elsif content.is_a?(Array)
+                  content.filter_map { |block| block['text'] if block.is_a?(Hash) && block['type'] == 'text' }
+                else
+                  next
+                end
+
+        texts.each do |text|
+          text = text.gsub(/\n+/, ' ').strip
+          next if text.empty?
+
+          if (m = text.match(COMMAND_NAME_RE))
+            command_fallback ||= m[1]
+            next
+          end
+
+          next if text.match?(SKIP_FIRST_PROMPT_PATTERN)
+
+          return text.length > 200 ? "#{text[0, 200]}…" : text
+        end
+      rescue JSON::ParserError
+        next
+      end
+
+      command_fallback || ''
+    end
+
+    # Read a single session file with lite (head/tail) strategy
+    def read_session_lite(file_path, project_path)
+      stat = File.stat(file_path)
+      return nil if stat.size.zero? # rubocop:disable Style/ZeroLengthPredicate
+
+      head, tail = read_head_tail(file_path, stat.size)
+
+      # Check first line for sidechain
+      first_line = head.lines.first || ''
+      return nil if first_line.include?('"isSidechain":true') || first_line.include?('"isSidechain": true')
+
+      build_session_info(file_path, head, tail, stat, project_path)
+    rescue StandardError
+      nil
+    end
+
+    def read_head_tail(file_path, size)
+      head = tail = nil
+      File.open(file_path, 'rb') do |f|
+        head = (f.read(LITE_READ_BUF_SIZE) || '').force_encoding('UTF-8')
+        tail = if size > LITE_READ_BUF_SIZE
+                 f.seek([0, size - LITE_READ_BUF_SIZE].max)
+                 (f.read(LITE_READ_BUF_SIZE) || '').force_encoding('UTF-8')
+               else
+                 head
+               end
+      end
+      [head, tail]
+    end
+
+    def build_session_info(file_path, head, tail, stat, project_path)
+      custom_title = extract_json_string_field(tail, 'customTitle', last: true)
+      first_prompt = extract_first_prompt_from_head(head)
+      summary = custom_title || extract_json_string_field(tail, 'summary', last: true) || first_prompt
+      return nil if summary.nil? || summary.strip.empty?
+
+      SDKSessionInfo.new(
+        session_id: File.basename(file_path, '.jsonl'),
+        summary: summary,
+        last_modified: (stat.mtime.to_f * 1000).to_i,
+        file_size: stat.size,
+        custom_title: custom_title,
+        first_prompt: first_prompt,
+        git_branch: extract_json_string_field(tail, 'gitBranch', last: true) ||
+                    extract_json_string_field(head, 'gitBranch', last: false),
+        cwd: extract_json_string_field(head, 'cwd', last: false) || project_path
+      )
+    end
+
+    # Read all sessions from a project directory
+    def read_sessions_from_dir(project_dir, project_path = nil)
+      return [] unless File.directory?(project_dir)
+
+      sessions = []
+      Dir.glob(File.join(project_dir, '*.jsonl')).each do |file_path|
+        stem = File.basename(file_path, '.jsonl')
+        next unless stem.match?(UUID_RE)
+
+        session = read_session_lite(file_path, project_path)
+        sessions << session if session
+      end
+      sessions
+    end
+
+    # List sessions for a directory (or all sessions)
+    # @param directory [String, nil] Working directory to list sessions for
+    # @param limit [Integer, nil] Maximum number of sessions to return
+    # @param include_worktrees [Boolean] Whether to include git worktree sessions
+    # @return [Array<SDKSessionInfo>] Sessions sorted by last_modified descending
+    def list_sessions(directory: nil, limit: nil, include_worktrees: true)
+      sessions = if directory
+                   list_sessions_for_directory(directory, include_worktrees)
+                 else
+                   list_all_sessions
+                 end
+
+      # Sort by last_modified descending
+      sessions.sort_by! { |s| -s.last_modified }
+      sessions = sessions.first(limit) if limit
+      sessions
+    end
+
+    # Get messages from a session transcript
+    # @param session_id [String] The session UUID
+    # @param directory [String, nil] Working directory to search in
+    # @param limit [Integer, nil] Maximum number of messages
+    # @param offset [Integer] Number of messages to skip
+    # @return [Array<SessionMessage>] Ordered messages from the session
+    def get_session_messages(session_id:, directory: nil, limit: nil, offset: 0)
+      return [] unless session_id.match?(UUID_RE)
+
+      file_path = find_session_file(session_id, directory)
+      return [] unless file_path && File.exist?(file_path)
+
+      entries = parse_jsonl_entries(file_path)
+      chain = build_conversation_chain(entries)
+      messages = filter_visible_messages(chain)
+
+      # Apply offset and limit
+      messages = messages[offset..] || []
+      messages = messages.first(limit) if limit
+      messages
+    end
+
+    # -- Private helpers --
+
+    def list_sessions_for_directory(directory, include_worktrees)
+      path = File.realpath(directory).unicode_normalize(:nfc)
+
+      worktree_paths = []
+      worktree_paths = detect_worktrees(path) if include_worktrees
+
+      if worktree_paths.length <= 1
+        project_dir = find_project_dir(path)
+        return project_dir ? read_sessions_from_dir(project_dir, path) : []
+      end
+
+      # Multiple worktrees: scan all project dirs for matches
+      all_sessions = []
+      worktree_paths.each do |wt_path|
+        project_dir = find_project_dir(wt_path)
+        next unless project_dir
+
+        all_sessions.concat(read_sessions_from_dir(project_dir, wt_path))
+      end
+
+      deduplicate_sessions(all_sessions)
+    end
+
+    def list_all_sessions
+      projects_dir = File.join(config_dir, 'projects')
+      return [] unless File.directory?(projects_dir)
+
+      all_sessions = []
+      Dir.children(projects_dir).each do |child|
+        dir = File.join(projects_dir, child)
+        next unless File.directory?(dir)
+
+        all_sessions.concat(read_sessions_from_dir(dir))
+      end
+
+      deduplicate_sessions(all_sessions)
+    end
+
+    def deduplicate_sessions(sessions)
+      by_id = {}
+      sessions.each do |s|
+        existing = by_id[s.session_id]
+        by_id[s.session_id] = s if existing.nil? || s.last_modified > existing.last_modified
+      end
+      by_id.values
+    end
+
+    def detect_worktrees(path)
+      output = `git -C #{Shellwords.escape(path)} worktree list --porcelain 2>/dev/null`
+      return [path] unless $CHILD_STATUS.success?
+
+      paths = output.lines.filter_map do |line|
+        line.strip.delete_prefix('worktree ') if line.start_with?('worktree ')
+      end
+      paths.empty? ? [path] : paths
+    rescue StandardError
+      [path]
+    end
+
+    def find_session_file(session_id, directory)
+      projects_dir = File.join(config_dir, 'projects')
+      return nil unless File.directory?(projects_dir)
+
+      if directory
+        path = File.realpath(directory).unicode_normalize(:nfc)
+        project_dir = find_project_dir(path)
+        if project_dir
+          candidate = File.join(project_dir, "#{session_id}.jsonl")
+          return candidate if File.exist?(candidate)
+        end
+
+        # Try worktrees
+        detect_worktrees(path).each do |wt_path|
+          pd = find_project_dir(wt_path)
+          next unless pd
+
+          candidate = File.join(pd, "#{session_id}.jsonl")
+          return candidate if File.exist?(candidate)
+        end
+      end
+
+      # Scan all project dirs
+      Dir.children(projects_dir).each do |child|
+        dir = File.join(projects_dir, child)
+        next unless File.directory?(dir)
+
+        candidate = File.join(dir, "#{session_id}.jsonl")
+        return candidate if File.exist?(candidate)
+      end
+
+      nil
+    end
+
+    def parse_jsonl_entries(file_path)
+      entries = []
+      valid_types = %w[user assistant progress system attachment].freeze
+
+      File.foreach(file_path) do |line|
+        entry = JSON.parse(line.strip, symbolize_names: false)
+        next unless entry.is_a?(Hash)
+        next unless valid_types.include?(entry['type'])
+        next unless entry['uuid'].is_a?(String)
+
+        entries << entry
+      rescue JSON::ParserError
+        next
+      end
+      entries
+    end
+
+    def build_conversation_chain(entries)
+      return [] if entries.empty?
+
+      by_uuid = {}
+      by_position = {}
+      parent_uuids = Set.new
+
+      entries.each_with_index do |entry, idx|
+        by_uuid[entry['uuid']] = entry
+        by_position[entry['uuid']] = idx
+        parent_uuids << entry['parentUuid'] if entry['parentUuid']
+      end
+
+      # Terminals: entries whose uuid is not any other entry's parentUuid
+      terminals = Set.new(by_uuid.keys) - parent_uuids
+
+      # Walk back from each terminal to find the nearest user/assistant leaf
+      leaf_candidates = terminals.filter_map do |uuid|
+        walk_to_leaf(by_uuid, uuid)
+      end
+
+      # Keep only main-chain candidates (not sidechain, team, or meta)
+      main_leaves = leaf_candidates.reject do |e|
+        e['isSidechain'] || e['teamName'] || e['isMeta']
+      end
+      return [] if main_leaves.empty?
+
+      # Pick the leaf with highest file position, walk to root
+      best_leaf = main_leaves.max_by { |e| by_position[e['uuid']] || 0 }
+      walk_to_root(by_uuid, best_leaf)
+    end
+
+    def walk_to_leaf(by_uuid, uuid)
+      current = by_uuid[uuid]
+      while current
+        return current if %w[user assistant].include?(current['type'])
+
+        parent = current['parentUuid']
+        current = parent ? by_uuid[parent] : nil
+      end
+    end
+
+    def walk_to_root(by_uuid, leaf)
+      chain = []
+      current = leaf
+      while current
+        chain << current
+        parent = current['parentUuid']
+        current = parent ? by_uuid[parent] : nil
+      end
+      chain.reverse
+    end
+
+    def filter_visible_messages(chain)
+      chain.filter_map do |entry|
+        next unless %w[user assistant].include?(entry['type'])
+        next if entry['isMeta']
+        next if entry['isSidechain']
+        next if entry['teamName']
+
+        SessionMessage.new(
+          type: entry['type'],
+          uuid: entry['uuid'],
+          session_id: entry['sessionId'] || entry['session_id'] || '',
+          message: entry['message']
+        )
+      end
+    end
+
+    private_class_method :list_sessions_for_directory, :list_all_sessions,
+                         :deduplicate_sessions, :detect_worktrees,
+                         :find_session_file, :parse_jsonl_entries,
+                         :build_conversation_chain, :walk_to_leaf, :walk_to_root,
+                         :filter_visible_messages, :read_head_tail, :build_session_info
+  end
+end

--- a/lib/claude_agent_sdk/sessions.rb
+++ b/lib/claude_agent_sdk/sessions.rb
@@ -449,9 +449,11 @@ module ClaudeAgentSDK
     end
 
     def walk_to_leaf(by_uuid, uuid)
+      visited = Set.new
       current = by_uuid[uuid]
       while current
         return current if %w[user assistant].include?(current['type'])
+        return nil unless visited.add?(current['uuid'])
 
         parent = current['parentUuid']
         current = parent ? by_uuid[parent] : nil
@@ -460,8 +462,11 @@ module ClaudeAgentSDK
 
     def walk_to_root(by_uuid, leaf)
       chain = []
+      visited = Set.new
       current = leaf
       while current
+        break unless visited.add?(current['uuid'])
+
         chain << current
         parent = current['parentUuid']
         current = parent ? by_uuid[parent] : nil

--- a/lib/claude_agent_sdk/types.rb
+++ b/lib/claude_agent_sdk/types.rb
@@ -698,6 +698,107 @@ module ClaudeAgentSDK
     end
   end
 
+  # MCP status response types
+
+  # MCP server connection status values
+  MCP_SERVER_CONNECTION_STATUSES = %w[connected failed needs-auth pending disabled].freeze
+
+  # MCP server info (name and version)
+  class McpServerInfo
+    attr_accessor :name, :version
+
+    def initialize(name:, version: nil)
+      @name = name
+      @version = version
+    end
+  end
+
+  # MCP tool annotation hints
+  class McpToolAnnotations
+    attr_accessor :read_only, :destructive, :open_world
+
+    def initialize(read_only: nil, destructive: nil, open_world: nil)
+      @read_only = read_only
+      @destructive = destructive
+      @open_world = open_world
+    end
+
+    def self.parse(data)
+      return nil unless data
+
+      new(
+        read_only: data[:readOnly] || data[:read_only],
+        destructive: data[:destructive],
+        open_world: data[:openWorld] || data[:open_world]
+      )
+    end
+  end
+
+  # MCP tool info (name, description, annotations)
+  class McpToolInfo
+    attr_accessor :name, :description, :annotations
+
+    def initialize(name:, description: nil, annotations: nil)
+      @name = name
+      @description = description
+      @annotations = annotations
+    end
+
+    def self.parse(data)
+      new(
+        name: data[:name],
+        description: data[:description],
+        annotations: McpToolAnnotations.parse(data[:annotations])
+      )
+    end
+  end
+
+  # Status of a single MCP server connection
+  class McpServerStatus
+    attr_accessor :name, :status, :server_info, :error, :config, :scope, :tools
+
+    def initialize(name:, status:, server_info: nil, error: nil, config: nil, scope: nil, tools: nil)
+      @name = name
+      @status = status
+      @server_info = server_info
+      @error = error
+      @config = config
+      @scope = scope
+      @tools = tools
+    end
+
+    def self.parse(data)
+      server_info = if data[:serverInfo]
+                      McpServerInfo.new(name: data[:serverInfo][:name], version: data[:serverInfo][:version])
+                    end
+      tools = data[:tools]&.map { |t| McpToolInfo.parse(t) }
+
+      new(
+        name: data[:name],
+        status: data[:status],
+        server_info: server_info,
+        error: data[:error],
+        config: data[:config],
+        scope: data[:scope],
+        tools: tools
+      )
+    end
+  end
+
+  # Response from get_mcp_status containing all server statuses
+  class McpStatusResponse
+    attr_accessor :mcp_servers
+
+    def initialize(mcp_servers:)
+      @mcp_servers = mcp_servers
+    end
+
+    def self.parse(data)
+      servers = (data[:mcpServers] || []).map { |s| McpServerStatus.parse(s) }
+      new(mcp_servers: servers)
+    end
+  end
+
   # MCP Server configurations
   class McpStdioServerConfig
     attr_accessor :type, :command, :args, :env

--- a/lib/claude_agent_sdk/types.rb
+++ b/lib/claude_agent_sdk/types.rb
@@ -727,9 +727,9 @@ module ClaudeAgentSDK
       return nil unless data
 
       new(
-        read_only: data[:readOnly] || data[:read_only],
+        read_only: data.key?(:readOnly) ? data[:readOnly] : data[:read_only],
         destructive: data[:destructive],
-        open_world: data[:openWorld] || data[:open_world]
+        open_world: data.key?(:openWorld) ? data[:openWorld] : data[:open_world]
       )
     end
   end

--- a/lib/claude_agent_sdk/types.rb
+++ b/lib/claude_agent_sdk/types.rb
@@ -181,20 +181,22 @@ module ClaudeAgentSDK
   # Result message with cost and usage information
   class ResultMessage
     attr_accessor :subtype, :duration_ms, :duration_api_ms, :is_error,
-                  :num_turns, :session_id, :total_cost_usd, :usage, :result, :structured_output
+                  :num_turns, :session_id, :stop_reason, :total_cost_usd, :usage, :result, :structured_output
 
     def initialize(subtype:, duration_ms:, duration_api_ms:, is_error:,
-                   num_turns:, session_id:, total_cost_usd: nil, usage: nil, result: nil, structured_output: nil)
+                   num_turns:, session_id:, stop_reason: nil, total_cost_usd: nil,
+                   usage: nil, result: nil, structured_output: nil)
       @subtype = subtype
       @duration_ms = duration_ms
       @duration_api_ms = duration_api_ms
       @is_error = is_error
       @num_turns = num_turns
       @session_id = session_id
+      @stop_reason = stop_reason
       @total_cost_usd = total_cost_usd
       @usage = usage
       @result = result
-      @structured_output = structured_output # Structured output when output_format is specified
+      @structured_output = structured_output
     end
   end
 

--- a/lib/claude_agent_sdk/types.rb
+++ b/lib/claude_agent_sdk/types.rb
@@ -124,6 +124,60 @@ module ClaudeAgentSDK
     end
   end
 
+  # Task lifecycle notification statuses
+  TASK_NOTIFICATION_STATUSES = %w[completed failed stopped].freeze
+
+  # Task started system message (subagent/background task started)
+  class TaskStartedMessage < SystemMessage
+    attr_accessor :task_id, :description, :uuid, :session_id, :tool_use_id, :task_type
+
+    def initialize(subtype:, data:, task_id:, description:, uuid:, session_id:,
+                   tool_use_id: nil, task_type: nil)
+      super(subtype: subtype, data: data)
+      @task_id = task_id
+      @description = description
+      @uuid = uuid
+      @session_id = session_id
+      @tool_use_id = tool_use_id
+      @task_type = task_type
+    end
+  end
+
+  # Task progress system message (periodic update from a running task)
+  class TaskProgressMessage < SystemMessage
+    attr_accessor :task_id, :description, :usage, :uuid, :session_id, :tool_use_id, :last_tool_name
+
+    def initialize(subtype:, data:, task_id:, description:, usage:, uuid:, session_id:,
+                   tool_use_id: nil, last_tool_name: nil)
+      super(subtype: subtype, data: data)
+      @task_id = task_id
+      @description = description
+      @usage = usage
+      @uuid = uuid
+      @session_id = session_id
+      @tool_use_id = tool_use_id
+      @last_tool_name = last_tool_name
+    end
+  end
+
+  # Task notification system message (task completed/failed/stopped)
+  class TaskNotificationMessage < SystemMessage
+    attr_accessor :task_id, :status, :output_file, :summary, :uuid, :session_id, :tool_use_id, :usage
+
+    def initialize(subtype:, data:, task_id:, status:, output_file:, summary:, uuid:, session_id:,
+                   tool_use_id: nil, usage: nil)
+      super(subtype: subtype, data: data)
+      @task_id = task_id
+      @status = status
+      @output_file = output_file
+      @summary = summary
+      @uuid = uuid
+      @session_id = session_id
+      @tool_use_id = tool_use_id
+      @usage = usage
+    end
+  end
+
   # Result message with cost and usage information
   class ResultMessage
     attr_accessor :subtype, :duration_ms, :duration_api_ms, :is_error,

--- a/lib/claude_agent_sdk/types.rb
+++ b/lib/claude_agent_sdk/types.rb
@@ -374,29 +374,34 @@ module ClaudeAgentSDK
 
   # PreToolUse hook input
   class PreToolUseHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :tool_name, :tool_input, :tool_use_id
+    attr_accessor :hook_event_name, :tool_name, :tool_input, :tool_use_id, :agent_id, :agent_type
 
-    def initialize(hook_event_name: 'PreToolUse', tool_name: nil, tool_input: nil, tool_use_id: nil, **base_args)
+    def initialize(hook_event_name: 'PreToolUse', tool_name: nil, tool_input: nil, tool_use_id: nil,
+                   agent_id: nil, agent_type: nil, **base_args)
       super(**base_args)
       @hook_event_name = hook_event_name
       @tool_name = tool_name
       @tool_input = tool_input
       @tool_use_id = tool_use_id
+      @agent_id = agent_id
+      @agent_type = agent_type
     end
   end
 
   # PostToolUse hook input
   class PostToolUseHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :tool_name, :tool_input, :tool_response, :tool_use_id
+    attr_accessor :hook_event_name, :tool_name, :tool_input, :tool_response, :tool_use_id, :agent_id, :agent_type
 
     def initialize(hook_event_name: 'PostToolUse', tool_name: nil, tool_input: nil, tool_response: nil,
-                   tool_use_id: nil, **base_args)
+                   tool_use_id: nil, agent_id: nil, agent_type: nil, **base_args)
       super(**base_args)
       @hook_event_name = hook_event_name
       @tool_name = tool_name
       @tool_input = tool_input
       @tool_response = tool_response
       @tool_use_id = tool_use_id
+      @agent_id = agent_id
+      @agent_type = agent_type
     end
   end
 
@@ -439,10 +444,11 @@ module ClaudeAgentSDK
 
   # PostToolUseFailure hook input
   class PostToolUseFailureHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :tool_name, :tool_input, :tool_use_id, :error, :is_interrupt
+    attr_accessor :hook_event_name, :tool_name, :tool_input, :tool_use_id, :error, :is_interrupt,
+                  :agent_id, :agent_type
 
     def initialize(hook_event_name: 'PostToolUseFailure', tool_name: nil, tool_input: nil, tool_use_id: nil,
-                   error: nil, is_interrupt: nil, **base_args)
+                   error: nil, is_interrupt: nil, agent_id: nil, agent_type: nil, **base_args)
       super(**base_args)
       @hook_event_name = hook_event_name
       @tool_name = tool_name
@@ -450,6 +456,8 @@ module ClaudeAgentSDK
       @tool_use_id = tool_use_id
       @error = error
       @is_interrupt = is_interrupt
+      @agent_id = agent_id
+      @agent_type = agent_type
     end
   end
 
@@ -480,15 +488,17 @@ module ClaudeAgentSDK
 
   # PermissionRequest hook input
   class PermissionRequestHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :tool_name, :tool_input, :permission_suggestions
+    attr_accessor :hook_event_name, :tool_name, :tool_input, :permission_suggestions, :agent_id, :agent_type
 
     def initialize(hook_event_name: 'PermissionRequest', tool_name: nil, tool_input: nil, permission_suggestions: nil,
-                   **base_args)
+                   agent_id: nil, agent_type: nil, **base_args)
       super(**base_args)
       @hook_event_name = hook_event_name
       @tool_name = tool_name
       @tool_input = tool_input
       @permission_suggestions = permission_suggestions
+      @agent_id = agent_id
+      @agent_type = agent_type
     end
   end
 

--- a/lib/claude_agent_sdk/types.rb
+++ b/lib/claude_agent_sdk/types.rb
@@ -768,9 +768,7 @@ module ClaudeAgentSDK
     end
 
     def self.parse(data)
-      server_info = if data[:serverInfo]
-                      McpServerInfo.new(name: data[:serverInfo][:name], version: data[:serverInfo][:version])
-                    end
+      server_info = (McpServerInfo.new(name: data[:serverInfo][:name], version: data[:serverInfo][:version]) if data[:serverInfo])
       tools = data[:tools]&.map { |t| McpToolInfo.parse(t) }
 
       new(

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -99,6 +99,69 @@ RSpec.describe ClaudeAgentSDK::Client do
     end
   end
 
+  it 'raises when reconnecting MCP server while not connected' do
+    client = described_class.new
+    expect { client.reconnect_mcp_server('my-server') }.to raise_error(ClaudeAgentSDK::CLIConnectionError)
+  end
+
+  it 'delegates reconnect_mcp_server when connected' do
+    transport = instance_double(ClaudeAgentSDK::SubprocessCLITransport, connect: true, write: nil)
+    query_handler = instance_double(
+      ClaudeAgentSDK::Query,
+      start: true, initialize_protocol: true,
+      reconnect_mcp_server: nil
+    )
+    allow(ClaudeAgentSDK::SubprocessCLITransport).to receive(:new).and_return(transport)
+    allow(ClaudeAgentSDK::Query).to receive(:new).and_return(query_handler)
+
+    client = described_class.new
+    client.connect
+    client.reconnect_mcp_server('my-server')
+    expect(query_handler).to have_received(:reconnect_mcp_server).with('my-server')
+  end
+
+  it 'raises when toggling MCP server while not connected' do
+    client = described_class.new
+    expect { client.toggle_mcp_server('my-server', true) }.to raise_error(ClaudeAgentSDK::CLIConnectionError)
+  end
+
+  it 'delegates toggle_mcp_server when connected' do
+    transport = instance_double(ClaudeAgentSDK::SubprocessCLITransport, connect: true, write: nil)
+    query_handler = instance_double(
+      ClaudeAgentSDK::Query,
+      start: true, initialize_protocol: true,
+      toggle_mcp_server: nil
+    )
+    allow(ClaudeAgentSDK::SubprocessCLITransport).to receive(:new).and_return(transport)
+    allow(ClaudeAgentSDK::Query).to receive(:new).and_return(query_handler)
+
+    client = described_class.new
+    client.connect
+    client.toggle_mcp_server('my-server', false)
+    expect(query_handler).to have_received(:toggle_mcp_server).with('my-server', false)
+  end
+
+  it 'raises when stopping task while not connected' do
+    client = described_class.new
+    expect { client.stop_task('task_1') }.to raise_error(ClaudeAgentSDK::CLIConnectionError)
+  end
+
+  it 'delegates stop_task when connected' do
+    transport = instance_double(ClaudeAgentSDK::SubprocessCLITransport, connect: true, write: nil)
+    query_handler = instance_double(
+      ClaudeAgentSDK::Query,
+      start: true, initialize_protocol: true,
+      stop_task: nil
+    )
+    allow(ClaudeAgentSDK::SubprocessCLITransport).to receive(:new).and_return(transport)
+    allow(ClaudeAgentSDK::Query).to receive(:new).and_return(query_handler)
+
+    client = described_class.new
+    client.connect
+    client.stop_task('task_abc')
+    expect(query_handler).to have_received(:stop_task).with('task_abc')
+  end
+
   it 'raises when requesting MCP status while not connected' do
     client = described_class.new
     expect { client.get_mcp_status }.to raise_error(ClaudeAgentSDK::CLIConnectionError)

--- a/spec/unit/message_parser_spec.rb
+++ b/spec/unit/message_parser_spec.rb
@@ -304,6 +304,23 @@ RSpec.describe ClaudeAgentSDK::MessageParser do
         expect(msg.usage).to be_nil
       end
 
+      it 'parses stop_reason' do
+        data = {
+          type: 'result',
+          subtype: 'success',
+          duration_ms: 1000,
+          duration_api_ms: 800,
+          is_error: false,
+          num_turns: 1,
+          session_id: 'test',
+          stop_reason: 'end_turn'
+        }
+
+        msg = described_class.parse(data)
+        expect(msg).to be_a(ClaudeAgentSDK::ResultMessage)
+        expect(msg.stop_reason).to eq('end_turn')
+      end
+
       it 'parses structured_output' do
         data = {
           type: 'result',

--- a/spec/unit/message_parser_spec.rb
+++ b/spec/unit/message_parser_spec.rb
@@ -192,6 +192,87 @@ RSpec.describe ClaudeAgentSDK::MessageParser do
         expect(msg.subtype).to eq('info')
         expect(msg.data).to include(message: 'Test system message')
       end
+
+      it 'parses task_started as TaskStartedMessage' do
+        data = {
+          type: 'system',
+          subtype: 'task_started',
+          task_id: 'task_abc',
+          description: 'Running background task',
+          uuid: 'uuid_123',
+          session_id: 'sess_1',
+          tool_use_id: 'toolu_1',
+          task_type: 'background'
+        }
+
+        msg = described_class.parse(data)
+        expect(msg).to be_a(ClaudeAgentSDK::TaskStartedMessage)
+        expect(msg).to be_a(ClaudeAgentSDK::SystemMessage)
+        expect(msg.task_id).to eq('task_abc')
+        expect(msg.description).to eq('Running background task')
+        expect(msg.uuid).to eq('uuid_123')
+        expect(msg.session_id).to eq('sess_1')
+        expect(msg.tool_use_id).to eq('toolu_1')
+        expect(msg.task_type).to eq('background')
+        expect(msg.subtype).to eq('task_started')
+        expect(msg.data).to eq(data)
+      end
+
+      it 'parses task_progress as TaskProgressMessage' do
+        data = {
+          type: 'system',
+          subtype: 'task_progress',
+          task_id: 'task_abc',
+          description: 'Still working',
+          usage: { total_tokens: 500, tool_uses: 3, duration_ms: 2000 },
+          uuid: 'uuid_456',
+          session_id: 'sess_1',
+          tool_use_id: 'toolu_2',
+          last_tool_name: 'Bash'
+        }
+
+        msg = described_class.parse(data)
+        expect(msg).to be_a(ClaudeAgentSDK::TaskProgressMessage)
+        expect(msg).to be_a(ClaudeAgentSDK::SystemMessage)
+        expect(msg.task_id).to eq('task_abc')
+        expect(msg.usage).to eq({ total_tokens: 500, tool_uses: 3, duration_ms: 2000 })
+        expect(msg.last_tool_name).to eq('Bash')
+      end
+
+      it 'parses task_notification as TaskNotificationMessage' do
+        data = {
+          type: 'system',
+          subtype: 'task_notification',
+          task_id: 'task_abc',
+          status: 'completed',
+          output_file: '/tmp/output.jsonl',
+          summary: 'Task completed successfully',
+          uuid: 'uuid_789',
+          session_id: 'sess_1',
+          usage: { total_tokens: 1000, tool_uses: 5, duration_ms: 5000 }
+        }
+
+        msg = described_class.parse(data)
+        expect(msg).to be_a(ClaudeAgentSDK::TaskNotificationMessage)
+        expect(msg).to be_a(ClaudeAgentSDK::SystemMessage)
+        expect(msg.status).to eq('completed')
+        expect(msg.output_file).to eq('/tmp/output.jsonl')
+        expect(msg.summary).to eq('Task completed successfully')
+        expect(msg.usage).to eq({ total_tokens: 1000, tool_uses: 5, duration_ms: 5000 })
+      end
+
+      it 'falls back to SystemMessage for unknown subtypes' do
+        data = {
+          type: 'system',
+          subtype: 'future_subtype',
+          some_field: 'value'
+        }
+
+        msg = described_class.parse(data)
+        expect(msg).to be_a(ClaudeAgentSDK::SystemMessage)
+        expect(msg).not_to be_a(ClaudeAgentSDK::TaskStartedMessage)
+        expect(msg.subtype).to eq('future_subtype')
+      end
     end
 
     context 'result messages' do

--- a/spec/unit/query_spec.rb
+++ b/spec/unit/query_spec.rb
@@ -4,6 +4,46 @@ require 'spec_helper'
 require 'async'
 
 RSpec.describe ClaudeAgentSDK::Query do
+  describe '#reconnect_mcp_server' do
+    it 'sends mcp_reconnect control request with camelCase serverName' do
+      transport = instance_double(ClaudeAgentSDK::Transport, write: nil)
+      query = described_class.new(transport: transport, is_streaming_mode: true)
+
+      expect(query).to receive(:send_control_request).with({
+                                                             subtype: 'mcp_reconnect',
+                                                             serverName: 'my-server'
+                                                           })
+      query.reconnect_mcp_server('my-server')
+    end
+  end
+
+  describe '#toggle_mcp_server' do
+    it 'sends mcp_toggle control request with serverName and enabled' do
+      transport = instance_double(ClaudeAgentSDK::Transport, write: nil)
+      query = described_class.new(transport: transport, is_streaming_mode: true)
+
+      expect(query).to receive(:send_control_request).with({
+                                                             subtype: 'mcp_toggle',
+                                                             serverName: 'my-server',
+                                                             enabled: false
+                                                           })
+      query.toggle_mcp_server('my-server', false)
+    end
+  end
+
+  describe '#stop_task' do
+    it 'sends stop_task control request with task_id' do
+      transport = instance_double(ClaudeAgentSDK::Transport, write: nil)
+      query = described_class.new(transport: transport, is_streaming_mode: true)
+
+      expect(query).to receive(:send_control_request).with({
+                                                             subtype: 'stop_task',
+                                                             task_id: 'task_abc123'
+                                                           })
+      query.stop_task('task_abc123')
+    end
+  end
+
   describe 'hook callbacks' do
     it 'passes typed hook input objects to callbacks' do
       transport = instance_double(ClaudeAgentSDK::Transport, write: nil)

--- a/spec/unit/query_spec.rb
+++ b/spec/unit/query_spec.rb
@@ -372,6 +372,59 @@ RSpec.describe ClaudeAgentSDK::Query do
       expect(result.tool_name).to eq('Bash')
     end
 
+    it 'populates agent_id and agent_type for PreToolUse events' do
+      transport = instance_double(ClaudeAgentSDK::Transport, write: nil)
+      query = described_class.new(transport: transport, is_streaming_mode: true)
+
+      input_data = {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: {},
+        agent_id: 'agent_abc',
+        agent_type: 'coder'
+      }
+
+      result = query.send(:parse_hook_input, input_data)
+      expect(result.agent_id).to eq('agent_abc')
+      expect(result.agent_type).to eq('coder')
+    end
+
+    it 'populates agent_id and agent_type for PostToolUseFailure events' do
+      transport = instance_double(ClaudeAgentSDK::Transport, write: nil)
+      query = described_class.new(transport: transport, is_streaming_mode: true)
+
+      input_data = {
+        hook_event_name: 'PostToolUseFailure',
+        tool_name: 'Bash',
+        tool_input: {},
+        agent_id: 'agent_xyz',
+        agent_type: 'tester'
+      }
+
+      result = query.send(:parse_hook_input, input_data)
+      expect(result).to be_a(ClaudeAgentSDK::PostToolUseFailureHookInput)
+      expect(result.agent_id).to eq('agent_xyz')
+      expect(result.agent_type).to eq('tester')
+    end
+
+    it 'populates agent_id and agent_type for PermissionRequest events' do
+      transport = instance_double(ClaudeAgentSDK::Transport, write: nil)
+      query = described_class.new(transport: transport, is_streaming_mode: true)
+
+      input_data = {
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Write',
+        tool_input: {},
+        agent_id: 'agent_perm',
+        agent_type: 'planner'
+      }
+
+      result = query.send(:parse_hook_input, input_data)
+      expect(result).to be_a(ClaudeAgentSDK::PermissionRequestHookInput)
+      expect(result.agent_id).to eq('agent_perm')
+      expect(result.agent_type).to eq('planner')
+    end
+
     it 'populates tool_use_id for PostToolUse events' do
       transport = instance_double(ClaudeAgentSDK::Transport, write: nil)
       query = described_class.new(transport: transport, is_streaming_mode: true)

--- a/spec/unit/sessions_spec.rb
+++ b/spec/unit/sessions_spec.rb
@@ -1,0 +1,460 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+require 'fileutils'
+require 'json'
+
+RSpec.describe ClaudeAgentSDK::Sessions do
+  describe '.simple_hash' do
+    it 'returns "0" for empty string' do
+      expect(described_class.simple_hash('')).to eq('0')
+    end
+
+    it 'produces consistent output for known inputs' do
+      # These must match TypeScript's simpleHash exactly
+      result = described_class.simple_hash('/Users/test/project')
+      expect(result).to be_a(String)
+      expect(result).to match(/\A[0-9a-z]+\z/)
+    end
+
+    it 'handles unicode characters' do
+      result = described_class.simple_hash('/Users/日本語/project')
+      expect(result).to be_a(String)
+      expect(result.length).to be > 0
+    end
+  end
+
+  describe '.sanitize_path' do
+    it 'replaces non-alphanumeric characters with hyphens' do
+      expect(described_class.sanitize_path('/Users/test/project')).to eq('-Users-test-project')
+    end
+
+    it 'returns as-is when under 200 chars' do
+      short_path = '/Users/test'
+      result = described_class.sanitize_path(short_path)
+      expect(result.length).to be <= 200
+      expect(result).not_to include('/')
+    end
+
+    it 'appends hash suffix for paths over 200 chars' do
+      long_path = "/Users/#{'a' * 300}/project"
+      result = described_class.sanitize_path(long_path)
+      expect(result.length).to be > 200
+      expect(result).to match(/-[0-9a-z]+\z/)
+    end
+  end
+
+  describe '.extract_json_string_field' do
+    it 'extracts first occurrence by default' do
+      text = '{"summary":"first"}\n{"summary":"second"}'
+      expect(described_class.extract_json_string_field(text, 'summary')).to eq('first')
+    end
+
+    it 'extracts last occurrence when last: true' do
+      text = '{"summary":"first"}\n{"summary":"second"}'
+      expect(described_class.extract_json_string_field(text, 'summary', last: true)).to eq('second')
+    end
+
+    it 'handles escaped characters' do
+      text = '{"title":"hello \\"world\\""}'
+      expect(described_class.extract_json_string_field(text, 'title')).to eq('hello "world"')
+    end
+
+    it 'returns nil when field not found' do
+      text = '{"other":"value"}'
+      expect(described_class.extract_json_string_field(text, 'missing')).to be_nil
+    end
+
+    it 'handles spacing after colon' do
+      text = '{"summary": "with space"}'
+      expect(described_class.extract_json_string_field(text, 'summary')).to eq('with space')
+    end
+  end
+
+  describe '.extract_first_prompt_from_head' do
+    it 'extracts plain string content' do
+      head = '{"type":"user","message":{"content":"Hello Claude"}}'
+      expect(described_class.extract_first_prompt_from_head(head)).to eq('Hello Claude')
+    end
+
+    it 'extracts text from content blocks' do
+      head = '{"type":"user","message":{"content":[{"type":"text","text":"Block text"}]}}'
+      expect(described_class.extract_first_prompt_from_head(head)).to eq('Block text')
+    end
+
+    it 'skips tool_result lines' do
+      lines = [
+        '{"type":"user","message":{"content":"tool result"},"tool_result":true}',
+        '{"type":"user","message":{"content":"Real prompt"}}'
+      ].join("\n")
+      expect(described_class.extract_first_prompt_from_head(lines)).to eq('Real prompt')
+    end
+
+    it 'skips isMeta lines' do
+      lines = [
+        '{"type":"user","message":{"content":"meta"},"isMeta":true}',
+        '{"type":"user","message":{"content":"Real prompt"}}'
+      ].join("\n")
+      expect(described_class.extract_first_prompt_from_head(lines)).to eq('Real prompt')
+    end
+
+    it 'skips session-start-hook content' do
+      lines = [
+        '{"type":"user","message":{"content":"<session-start-hook>stuff"}}',
+        '{"type":"user","message":{"content":"Real prompt"}}'
+      ].join("\n")
+      expect(described_class.extract_first_prompt_from_head(lines)).to eq('Real prompt')
+    end
+
+    it 'truncates long prompts to 200 chars with ellipsis' do
+      long_text = 'x' * 300
+      head = "{\"type\":\"user\",\"message\":{\"content\":\"#{long_text}\"}}"
+      result = described_class.extract_first_prompt_from_head(head)
+      expect(result.length).to eq(201) # 200 + ellipsis character
+      expect(result).to end_with('…')
+    end
+
+    it 'returns empty string when no valid prompt found' do
+      head = '{"type":"assistant","message":{"content":"Not a user message"}}'
+      expect(described_class.extract_first_prompt_from_head(head)).to eq('')
+    end
+
+    it 'extracts command name as fallback' do
+      head = '{"type":"user","message":{"content":"<command-name>commit</command-name>"}}'
+      expect(described_class.extract_first_prompt_from_head(head)).to eq('commit')
+    end
+  end
+
+  describe '.read_session_lite' do
+    it 'reads a valid session file' do
+      Dir.mktmpdir do |dir|
+        session_id = '12345678-1234-1234-1234-123456789abc'
+        file_path = File.join(dir, "#{session_id}.jsonl")
+        File.write(file_path, [
+          { type: 'user', uuid: 'u1', message: { content: 'Hello' } }.to_json,
+          { type: 'assistant', uuid: 'a1', message: { content: 'Hi!' } }.to_json
+        ].join("\n"))
+
+        result = described_class.read_session_lite(file_path, '/test')
+        expect(result).to be_a(ClaudeAgentSDK::SDKSessionInfo)
+        expect(result.session_id).to eq(session_id)
+        expect(result.first_prompt).to eq('Hello')
+        expect(result.summary).to eq('Hello')
+        expect(result.file_size).to be > 0
+        expect(result.last_modified).to be > 0
+      end
+    end
+
+    it 'returns nil for sidechain files' do
+      Dir.mktmpdir do |dir|
+        file_path = File.join(dir, '12345678-1234-1234-1234-123456789abc.jsonl')
+        File.write(file_path, { type: 'user', isSidechain: true, message: { content: 'x' } }.to_json)
+
+        expect(described_class.read_session_lite(file_path, '/test')).to be_nil
+      end
+    end
+
+    it 'returns nil for empty files' do
+      Dir.mktmpdir do |dir|
+        file_path = File.join(dir, '12345678-1234-1234-1234-123456789abc.jsonl')
+        File.write(file_path, '')
+
+        expect(described_class.read_session_lite(file_path, '/test')).to be_nil
+      end
+    end
+
+    it 'prefers customTitle as summary' do
+      Dir.mktmpdir do |dir|
+        file_path = File.join(dir, '12345678-1234-1234-1234-123456789abc.jsonl')
+        File.write(file_path, [
+          { type: 'user', uuid: 'u1', message: { content: 'Hello' } }.to_json,
+          { type: 'system', uuid: 's1', customTitle: 'My Custom Title' }.to_json
+        ].join("\n"))
+
+        result = described_class.read_session_lite(file_path, '/test')
+        expect(result.summary).to eq('My Custom Title')
+        expect(result.custom_title).to eq('My Custom Title')
+      end
+    end
+  end
+
+  describe '.read_sessions_from_dir' do
+    it 'reads all valid session files from a directory' do
+      Dir.mktmpdir do |dir|
+        # Valid session file
+        File.write(
+          File.join(dir, '12345678-1234-1234-1234-123456789abc.jsonl'),
+          { type: 'user', uuid: 'u1', message: { content: 'Hello' } }.to_json
+        )
+        # Another valid session file
+        File.write(
+          File.join(dir, 'abcdef01-2345-6789-abcd-ef0123456789.jsonl'),
+          { type: 'user', uuid: 'u2', message: { content: 'World' } }.to_json
+        )
+        # Invalid filename (not UUID)
+        File.write(File.join(dir, 'not-a-uuid.jsonl'), 'ignored')
+        # Non-JSONL file
+        File.write(File.join(dir, 'readme.txt'), 'ignored')
+
+        sessions = described_class.read_sessions_from_dir(dir)
+        expect(sessions.length).to eq(2)
+        expect(sessions.map(&:session_id)).to contain_exactly(
+          '12345678-1234-1234-1234-123456789abc',
+          'abcdef01-2345-6789-abcd-ef0123456789'
+        )
+      end
+    end
+
+    it 'returns empty array for non-existent directory' do
+      expect(described_class.read_sessions_from_dir('/nonexistent')).to eq([])
+    end
+  end
+
+  describe '.list_sessions' do
+    it 'returns empty array when no config dir exists' do
+      allow(described_class).to receive(:config_dir).and_return('/nonexistent')
+      expect(described_class.list_sessions).to eq([])
+    end
+
+    it 'respects limit parameter' do
+      Dir.mktmpdir do |config_dir|
+        allow(described_class).to receive(:config_dir).and_return(config_dir)
+
+        project_dir = File.join(config_dir, 'projects', '-test')
+        FileUtils.mkdir_p(project_dir)
+
+        3.times do |i|
+          uuid = "12345678-1234-1234-1234-12345678900#{i}"
+          File.write(
+            File.join(project_dir, "#{uuid}.jsonl"),
+            { type: 'user', uuid: "u#{i}", message: { content: "Prompt #{i}" } }.to_json
+          )
+          # Ensure different mtimes
+          FileUtils.touch(File.join(project_dir, "#{uuid}.jsonl"), mtime: Time.now + i)
+        end
+
+        sessions = described_class.list_sessions(limit: 2)
+        expect(sessions.length).to eq(2)
+      end
+    end
+
+    it 'sorts by last_modified descending' do
+      Dir.mktmpdir do |config_dir|
+        allow(described_class).to receive(:config_dir).and_return(config_dir)
+
+        project_dir = File.join(config_dir, 'projects', '-test')
+        FileUtils.mkdir_p(project_dir)
+
+        uuid_old = '12345678-1234-1234-1234-123456789000'
+        uuid_new = '12345678-1234-1234-1234-123456789001'
+
+        File.write(
+          File.join(project_dir, "#{uuid_old}.jsonl"),
+          { type: 'user', uuid: 'u1', message: { content: 'Old' } }.to_json
+        )
+        FileUtils.touch(File.join(project_dir, "#{uuid_old}.jsonl"), mtime: Time.now - 100)
+
+        File.write(
+          File.join(project_dir, "#{uuid_new}.jsonl"),
+          { type: 'user', uuid: 'u2', message: { content: 'New' } }.to_json
+        )
+
+        sessions = described_class.list_sessions
+        expect(sessions.first.session_id).to eq(uuid_new)
+      end
+    end
+  end
+
+  describe '.get_session_messages' do
+    it 'returns empty for invalid session_id' do
+      expect(described_class.get_session_messages(session_id: 'not-a-uuid')).to eq([])
+    end
+
+    it 'returns empty when session file not found' do
+      allow(described_class).to receive(:config_dir).and_return('/nonexistent')
+      expect(described_class.get_session_messages(session_id: '12345678-1234-1234-1234-123456789abc')).to eq([])
+    end
+
+    it 'parses a simple conversation' do
+      Dir.mktmpdir do |config_dir|
+        allow(described_class).to receive(:config_dir).and_return(config_dir)
+
+        session_id = '12345678-1234-1234-1234-123456789abc'
+        project_dir = File.join(config_dir, 'projects', '-test')
+        FileUtils.mkdir_p(project_dir)
+
+        entries = [
+          {
+            type: 'user', uuid: 'msg-1', sessionId: session_id,
+            message: { role: 'user', content: 'Hello' }
+          },
+          {
+            type: 'assistant', uuid: 'msg-2', parentUuid: 'msg-1', sessionId: session_id,
+            message: { role: 'assistant', content: [{ type: 'text', text: 'Hi!' }] }
+          }
+        ]
+
+        File.write(
+          File.join(project_dir, "#{session_id}.jsonl"),
+          entries.map(&:to_json).join("\n")
+        )
+
+        messages = described_class.get_session_messages(session_id: session_id)
+        expect(messages.length).to eq(2)
+        expect(messages[0]).to be_a(ClaudeAgentSDK::SessionMessage)
+        expect(messages[0].type).to eq('user')
+        expect(messages[0].uuid).to eq('msg-1')
+        expect(messages[1].type).to eq('assistant')
+      end
+    end
+
+    it 'filters out sidechain messages' do
+      Dir.mktmpdir do |config_dir|
+        allow(described_class).to receive(:config_dir).and_return(config_dir)
+
+        session_id = '12345678-1234-1234-1234-123456789abc'
+        project_dir = File.join(config_dir, 'projects', '-test')
+        FileUtils.mkdir_p(project_dir)
+
+        # Main chain: msg-1 → msg-2 → msg-3 (continues main)
+        # Sidechain: msg-4 branches off msg-2
+        entries = [
+          { type: 'user', uuid: 'msg-1', sessionId: session_id, message: { content: 'Hello' } },
+          { type: 'assistant', uuid: 'msg-2', parentUuid: 'msg-1', sessionId: session_id,
+            message: { content: 'Hi' } },
+          { type: 'user', uuid: 'msg-3', parentUuid: 'msg-2', sessionId: session_id,
+            message: { content: 'Follow up' } },
+          { type: 'user', uuid: 'msg-4', parentUuid: 'msg-2', isSidechain: true,
+            sessionId: session_id, message: { content: 'Side branch' } }
+        ]
+
+        File.write(
+          File.join(project_dir, "#{session_id}.jsonl"),
+          entries.map(&:to_json).join("\n")
+        )
+
+        messages = described_class.get_session_messages(session_id: session_id)
+        expect(messages.length).to eq(3)
+        expect(messages.map(&:uuid)).to eq(%w[msg-1 msg-2 msg-3])
+        expect(messages.none? { |m| m.uuid == 'msg-4' }).to be true
+      end
+    end
+
+    it 'filters out meta messages' do
+      Dir.mktmpdir do |config_dir|
+        allow(described_class).to receive(:config_dir).and_return(config_dir)
+
+        session_id = '12345678-1234-1234-1234-123456789abc'
+        project_dir = File.join(config_dir, 'projects', '-test')
+        FileUtils.mkdir_p(project_dir)
+
+        entries = [
+          { type: 'user', uuid: 'msg-1', sessionId: session_id, isMeta: true,
+            message: { content: 'Meta' } },
+          { type: 'user', uuid: 'msg-2', sessionId: session_id,
+            message: { content: 'Real' } },
+          { type: 'assistant', uuid: 'msg-3', parentUuid: 'msg-2', sessionId: session_id,
+            message: { content: 'Response' } }
+        ]
+
+        File.write(
+          File.join(project_dir, "#{session_id}.jsonl"),
+          entries.map(&:to_json).join("\n")
+        )
+
+        messages = described_class.get_session_messages(session_id: session_id)
+        expect(messages.none? { |m| m.uuid == 'msg-1' }).to be true
+      end
+    end
+
+    it 'applies offset and limit' do
+      Dir.mktmpdir do |config_dir|
+        allow(described_class).to receive(:config_dir).and_return(config_dir)
+
+        session_id = '12345678-1234-1234-1234-123456789abc'
+        project_dir = File.join(config_dir, 'projects', '-test')
+        FileUtils.mkdir_p(project_dir)
+
+        entries = [
+          { type: 'user', uuid: 'msg-1', sessionId: session_id, message: { content: 'First' } },
+          { type: 'assistant', uuid: 'msg-2', parentUuid: 'msg-1', sessionId: session_id,
+            message: { content: 'Second' } },
+          { type: 'user', uuid: 'msg-3', parentUuid: 'msg-2', sessionId: session_id,
+            message: { content: 'Third' } },
+          { type: 'assistant', uuid: 'msg-4', parentUuid: 'msg-3', sessionId: session_id,
+            message: { content: 'Fourth' } }
+        ]
+
+        File.write(
+          File.join(project_dir, "#{session_id}.jsonl"),
+          entries.map(&:to_json).join("\n")
+        )
+
+        messages = described_class.get_session_messages(session_id: session_id, offset: 1, limit: 2)
+        expect(messages.length).to eq(2)
+        expect(messages[0].uuid).to eq('msg-2')
+        expect(messages[1].uuid).to eq('msg-3')
+      end
+    end
+  end
+end
+
+RSpec.describe ClaudeAgentSDK::SDKSessionInfo do
+  it 'stores all fields' do
+    info = described_class.new(
+      session_id: 'abc-123',
+      summary: 'Test session',
+      last_modified: 1_000_000,
+      file_size: 4096,
+      custom_title: 'My Title',
+      first_prompt: 'Hello',
+      git_branch: 'main',
+      cwd: '/test'
+    )
+
+    expect(info.session_id).to eq('abc-123')
+    expect(info.summary).to eq('Test session')
+    expect(info.last_modified).to eq(1_000_000)
+    expect(info.file_size).to eq(4096)
+    expect(info.custom_title).to eq('My Title')
+    expect(info.first_prompt).to eq('Hello')
+    expect(info.git_branch).to eq('main')
+    expect(info.cwd).to eq('/test')
+  end
+end
+
+RSpec.describe ClaudeAgentSDK::SessionMessage do
+  it 'stores message data' do
+    msg = described_class.new(
+      type: 'user',
+      uuid: 'msg-1',
+      session_id: 'sess-1',
+      message: { 'role' => 'user', 'content' => 'Hello' }
+    )
+
+    expect(msg.type).to eq('user')
+    expect(msg.uuid).to eq('msg-1')
+    expect(msg.session_id).to eq('sess-1')
+    expect(msg.message).to eq({ 'role' => 'user', 'content' => 'Hello' })
+    expect(msg.parent_tool_use_id).to be_nil
+  end
+end
+
+RSpec.describe 'ClaudeAgentSDK top-level session functions' do
+  it 'delegates list_sessions to Sessions module' do
+    expect(ClaudeAgentSDK::Sessions).to receive(:list_sessions)
+      .with(directory: '/test', limit: 5, include_worktrees: false)
+      .and_return([])
+
+    ClaudeAgentSDK.list_sessions(directory: '/test', limit: 5, include_worktrees: false)
+  end
+
+  it 'delegates get_session_messages to Sessions module' do
+    expect(ClaudeAgentSDK::Sessions).to receive(:get_session_messages)
+      .with(session_id: 'abc', directory: nil, limit: nil, offset: 0)
+      .and_return([])
+
+    ClaudeAgentSDK.get_session_messages(session_id: 'abc')
+  end
+end

--- a/spec/unit/sessions_spec.rb
+++ b/spec/unit/sessions_spec.rb
@@ -368,6 +368,35 @@ RSpec.describe ClaudeAgentSDK::Sessions do
       end
     end
 
+    it 'handles circular parentUuid references without infinite loop' do
+      Dir.mktmpdir do |config_dir|
+        allow(described_class).to receive(:config_dir).and_return(config_dir)
+
+        session_id = '12345678-1234-1234-1234-123456789abc'
+        project_dir = File.join(config_dir, 'projects', '-test')
+        FileUtils.mkdir_p(project_dir)
+
+        # msg-1 and msg-2 form a cycle, msg-3 is a terminal that leads into the cycle
+        entries = [
+          { type: 'user', uuid: 'msg-1', parentUuid: 'msg-2', sessionId: session_id,
+            message: { content: 'First' } },
+          { type: 'assistant', uuid: 'msg-2', parentUuid: 'msg-1', sessionId: session_id,
+            message: { content: 'Second' } },
+          { type: 'system', uuid: 'msg-3', parentUuid: 'msg-2', sessionId: session_id,
+            message: { content: 'System' } }
+        ]
+
+        File.write(
+          File.join(project_dir, "#{session_id}.jsonl"),
+          entries.map(&:to_json).join("\n")
+        )
+
+        # Should not hang — returns some result without infinite looping
+        messages = described_class.get_session_messages(session_id: session_id)
+        expect(messages.length).to be <= 3
+      end
+    end
+
     it 'applies offset and limit' do
       Dir.mktmpdir do |config_dir|
         allow(described_class).to receive(:config_dir).and_return(config_dir)

--- a/spec/unit/types_spec.rb
+++ b/spec/unit/types_spec.rb
@@ -96,6 +96,112 @@ RSpec.describe ClaudeAgentSDK do
       end
     end
 
+    describe ClaudeAgentSDK::TaskStartedMessage do
+      it 'is a SystemMessage subclass' do
+        msg = described_class.new(
+          subtype: 'task_started',
+          data: {},
+          task_id: 'task_1',
+          description: 'Working on feature',
+          uuid: 'uuid_123',
+          session_id: 'sess_1'
+        )
+        expect(msg).to be_a(ClaudeAgentSDK::SystemMessage)
+        expect(msg.task_id).to eq('task_1')
+        expect(msg.description).to eq('Working on feature')
+        expect(msg.uuid).to eq('uuid_123')
+        expect(msg.session_id).to eq('sess_1')
+      end
+
+      it 'stores optional fields' do
+        msg = described_class.new(
+          subtype: 'task_started',
+          data: {},
+          task_id: 'task_1',
+          description: 'test',
+          uuid: 'uuid_1',
+          session_id: 'sess_1',
+          tool_use_id: 'toolu_1',
+          task_type: 'background'
+        )
+        expect(msg.tool_use_id).to eq('toolu_1')
+        expect(msg.task_type).to eq('background')
+      end
+    end
+
+    describe ClaudeAgentSDK::TaskProgressMessage do
+      it 'is a SystemMessage subclass' do
+        msg = described_class.new(
+          subtype: 'task_progress',
+          data: {},
+          task_id: 'task_1',
+          description: 'In progress',
+          usage: { total_tokens: 500, tool_uses: 3, duration_ms: 2000 },
+          uuid: 'uuid_123',
+          session_id: 'sess_1'
+        )
+        expect(msg).to be_a(ClaudeAgentSDK::SystemMessage)
+        expect(msg.task_id).to eq('task_1')
+        expect(msg.description).to eq('In progress')
+        expect(msg.usage).to eq({ total_tokens: 500, tool_uses: 3, duration_ms: 2000 })
+        expect(msg.uuid).to eq('uuid_123')
+        expect(msg.session_id).to eq('sess_1')
+      end
+
+      it 'stores optional fields' do
+        msg = described_class.new(
+          subtype: 'task_progress',
+          data: {},
+          task_id: 'task_1',
+          description: 'test',
+          usage: {},
+          uuid: 'uuid_1',
+          session_id: 'sess_1',
+          tool_use_id: 'toolu_1',
+          last_tool_name: 'Bash'
+        )
+        expect(msg.tool_use_id).to eq('toolu_1')
+        expect(msg.last_tool_name).to eq('Bash')
+      end
+    end
+
+    describe ClaudeAgentSDK::TaskNotificationMessage do
+      it 'is a SystemMessage subclass' do
+        msg = described_class.new(
+          subtype: 'task_notification',
+          data: {},
+          task_id: 'task_1',
+          status: 'completed',
+          output_file: '/tmp/output.txt',
+          summary: 'Task finished',
+          uuid: 'uuid_123',
+          session_id: 'sess_1'
+        )
+        expect(msg).to be_a(ClaudeAgentSDK::SystemMessage)
+        expect(msg.task_id).to eq('task_1')
+        expect(msg.status).to eq('completed')
+        expect(msg.output_file).to eq('/tmp/output.txt')
+        expect(msg.summary).to eq('Task finished')
+      end
+
+      it 'stores optional fields' do
+        msg = described_class.new(
+          subtype: 'task_notification',
+          data: {},
+          task_id: 'task_1',
+          status: 'failed',
+          output_file: '/tmp/out.txt',
+          summary: 'failed',
+          uuid: 'uuid_1',
+          session_id: 'sess_1',
+          tool_use_id: 'toolu_1',
+          usage: { total_tokens: 100, tool_uses: 1, duration_ms: 500 }
+        )
+        expect(msg.tool_use_id).to eq('toolu_1')
+        expect(msg.usage).to eq({ total_tokens: 100, tool_uses: 1, duration_ms: 500 })
+      end
+    end
+
     describe ClaudeAgentSDK::ResultMessage do
       it 'stores result information' do
         msg = described_class.new(

--- a/spec/unit/types_spec.rb
+++ b/spec/unit/types_spec.rb
@@ -221,6 +221,33 @@ RSpec.describe ClaudeAgentSDK do
         expect(msg.total_cost_usd).to eq(0.01)
       end
 
+      it 'stores stop_reason' do
+        msg = described_class.new(
+          subtype: 'success',
+          duration_ms: 1000,
+          duration_api_ms: 800,
+          is_error: false,
+          num_turns: 1,
+          session_id: 'session_123',
+          stop_reason: 'end_turn'
+        )
+
+        expect(msg.stop_reason).to eq('end_turn')
+      end
+
+      it 'defaults stop_reason to nil' do
+        msg = described_class.new(
+          subtype: 'success',
+          duration_ms: 1000,
+          duration_api_ms: 800,
+          is_error: false,
+          num_turns: 1,
+          session_id: 'session_123'
+        )
+
+        expect(msg.stop_reason).to be_nil
+      end
+
       it 'stores structured_output' do
         msg = described_class.new(
           subtype: 'success',

--- a/spec/unit/types_spec.rb
+++ b/spec/unit/types_spec.rb
@@ -640,6 +640,92 @@ RSpec.describe ClaudeAgentSDK do
       end
     end
 
+    describe ClaudeAgentSDK::McpServerInfo do
+      it 'stores server name and version' do
+        info = described_class.new(name: 'my-server', version: '1.0.0')
+        expect(info.name).to eq('my-server')
+        expect(info.version).to eq('1.0.0')
+      end
+    end
+
+    describe ClaudeAgentSDK::McpToolAnnotations do
+      it 'stores annotation hints' do
+        annotations = described_class.new(read_only: true, destructive: false, open_world: true)
+        expect(annotations.read_only).to eq(true)
+        expect(annotations.destructive).to eq(false)
+        expect(annotations.open_world).to eq(true)
+      end
+    end
+
+    describe ClaudeAgentSDK::McpToolInfo do
+      it 'stores tool name and description' do
+        tool = described_class.new(name: 'read_file', description: 'Read a file')
+        expect(tool.name).to eq('read_file')
+        expect(tool.description).to eq('Read a file')
+      end
+
+      it 'stores annotations' do
+        annotations = ClaudeAgentSDK::McpToolAnnotations.new(read_only: true)
+        tool = described_class.new(name: 'read_file', annotations: annotations)
+        expect(tool.annotations.read_only).to eq(true)
+      end
+    end
+
+    describe ClaudeAgentSDK::McpServerStatus do
+      it 'stores all fields' do
+        info = ClaudeAgentSDK::McpServerInfo.new(name: 'srv', version: '1.0')
+        status = described_class.new(
+          name: 'my-server',
+          status: 'connected',
+          server_info: info,
+          error: nil,
+          scope: 'project',
+          tools: []
+        )
+        expect(status.name).to eq('my-server')
+        expect(status.status).to eq('connected')
+        expect(status.server_info.name).to eq('srv')
+        expect(status.scope).to eq('project')
+      end
+
+      it 'parses from raw hash with camelCase keys' do
+        raw = {
+          name: 'test-server',
+          status: 'connected',
+          serverInfo: { name: 'test', version: '2.0' },
+          tools: [
+            { name: 'tool1', description: 'desc1', annotations: { readOnly: true } }
+          ],
+          scope: 'user'
+        }
+        status = described_class.parse(raw)
+        expect(status.name).to eq('test-server')
+        expect(status.status).to eq('connected')
+        expect(status.server_info).to be_a(ClaudeAgentSDK::McpServerInfo)
+        expect(status.server_info.version).to eq('2.0')
+        expect(status.tools.length).to eq(1)
+        expect(status.tools.first).to be_a(ClaudeAgentSDK::McpToolInfo)
+        expect(status.tools.first.annotations.read_only).to eq(true)
+      end
+    end
+
+    describe ClaudeAgentSDK::McpStatusResponse do
+      it 'parses from raw hash' do
+        raw = {
+          mcpServers: [
+            { name: 'server1', status: 'connected' },
+            { name: 'server2', status: 'failed', error: 'timeout' }
+          ]
+        }
+        response = described_class.parse(raw)
+        expect(response.mcp_servers.length).to eq(2)
+        expect(response.mcp_servers[0]).to be_a(ClaudeAgentSDK::McpServerStatus)
+        expect(response.mcp_servers[0].name).to eq('server1')
+        expect(response.mcp_servers[1].status).to eq('failed')
+        expect(response.mcp_servers[1].error).to eq('timeout')
+      end
+    end
+
     describe ClaudeAgentSDK::SdkMcpTool do
       it 'stores tool definition' do
         handler = ->(_args) { { content: [] } }

--- a/spec/unit/types_spec.rb
+++ b/spec/unit/types_spec.rb
@@ -655,6 +655,21 @@ RSpec.describe ClaudeAgentSDK do
         expect(annotations.destructive).to eq(false)
         expect(annotations.open_world).to eq(true)
       end
+
+      it 'parses false values correctly from camelCase keys' do
+        data = { readOnly: false, destructive: false, openWorld: false }
+        annotations = described_class.parse(data)
+        expect(annotations.read_only).to eq(false)
+        expect(annotations.destructive).to eq(false)
+        expect(annotations.open_world).to eq(false)
+      end
+
+      it 'falls back to snake_case keys when camelCase is absent' do
+        data = { read_only: true, open_world: false }
+        annotations = described_class.parse(data)
+        expect(annotations.read_only).to eq(true)
+        expect(annotations.open_world).to eq(false)
+      end
     end
 
     describe ClaudeAgentSDK::McpToolInfo do

--- a/spec/unit/types_spec.rb
+++ b/spec/unit/types_spec.rb
@@ -377,6 +377,23 @@ RSpec.describe ClaudeAgentSDK do
         expect(input.session_id).to eq('sess_123')
         expect(input.cwd).to eq('/home/user')
       end
+
+      it 'stores agent_id and agent_type for subagent context' do
+        input = described_class.new(
+          tool_name: 'Bash',
+          tool_input: { command: 'ls' },
+          agent_id: 'agent_abc',
+          agent_type: 'coder'
+        )
+        expect(input.agent_id).to eq('agent_abc')
+        expect(input.agent_type).to eq('coder')
+      end
+
+      it 'defaults agent_id and agent_type to nil' do
+        input = described_class.new(tool_name: 'Bash')
+        expect(input.agent_id).to be_nil
+        expect(input.agent_type).to be_nil
+      end
     end
 
     describe ClaudeAgentSDK::PostToolUseHookInput do
@@ -389,6 +406,16 @@ RSpec.describe ClaudeAgentSDK do
 
         expect(input.hook_event_name).to eq('PostToolUse')
         expect(input.tool_response).to eq('file1.txt\nfile2.txt')
+      end
+
+      it 'stores agent_id and agent_type for subagent context' do
+        input = described_class.new(
+          tool_name: 'Bash',
+          agent_id: 'agent_1',
+          agent_type: 'researcher'
+        )
+        expect(input.agent_id).to eq('agent_1')
+        expect(input.agent_type).to eq('researcher')
       end
     end
 
@@ -410,6 +437,16 @@ RSpec.describe ClaudeAgentSDK do
         expect(input.error).to eq('Command blocked')
         expect(input.is_interrupt).to eq(true)
         expect(input.session_id).to eq('sess_123')
+      end
+
+      it 'stores agent_id and agent_type for subagent context' do
+        input = described_class.new(
+          tool_name: 'Bash',
+          agent_id: 'agent_2',
+          agent_type: 'tester'
+        )
+        expect(input.agent_id).to eq('agent_2')
+        expect(input.agent_type).to eq('tester')
       end
     end
 
@@ -450,6 +487,16 @@ RSpec.describe ClaudeAgentSDK do
         expect(input.tool_name).to eq('Bash')
         expect(input.tool_input).to eq({ command: 'ls' })
         expect(input.permission_suggestions).to eq([{ type: 'setMode', mode: 'default' }])
+      end
+
+      it 'stores agent_id and agent_type for subagent context' do
+        input = described_class.new(
+          tool_name: 'Bash',
+          agent_id: 'agent_3',
+          agent_type: 'planner'
+        )
+        expect(input.agent_id).to eq('agent_3')
+        expect(input.agent_type).to eq('planner')
       end
     end
 


### PR DESCRIPTION
## Summary

- **Task message subtypes**: Add `TaskStartedMessage`, `TaskProgressMessage`, `TaskNotificationMessage` as `SystemMessage` subclasses with parser dispatch on `subtype`
- **New client control methods**: Add `reconnect_mcp_server`, `toggle_mcp_server`, `stop_task` to both `Query` and `Client`
- **Subagent context on hook inputs**: Add `agent_id`/`agent_type` to `PreToolUseHookInput`, `PostToolUseHookInput`, `PostToolUseFailureHookInput`, `PermissionRequestHookInput`
- **ResultMessage.stop_reason**: Add optional `stop_reason` field (e.g., `end_turn`, `max_tokens`)
- **Typed MCP status types**: Add `McpServerStatus`, `McpStatusResponse`, `McpServerInfo`, `McpToolInfo`, `McpToolAnnotations` with `.parse` class methods
- **Session browsing functions**: Add `list_sessions` and `get_session_messages` top-level functions with `SDKSessionInfo`/`SessionMessage` types — pure filesystem operations reading `~/.claude/projects/` JSONL files

## Test plan

- [x] 300 unit tests passing (65 new tests added)
- [x] 0 RuboCop offenses
- [x] `bundle exec rake` (rspec + rubocop) green
- [ ] Integration test with Claude Code CLI (requires `RUN_INTEGRATION=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)