### PR TITLE
Add custom transport support to Client

### DIFF
--- a/lib/claude_agent_sdk.rb
+++ b/lib/claude_agent_sdk.rb
@@ -239,8 +239,14 @@ module ClaudeAgentSDK
   class Client
     attr_reader :query_handler
 
-    def initialize(options: nil)
+    # @param options [ClaudeAgentOptions, nil] Configuration options
+    # @param transport_class [Class] Transport class to use (must implement Transport interface).
+    #   Defaults to SubprocessCLITransport.
+    # @param transport_args [Hash] Additional keyword arguments passed to transport_class.new(options, **transport_args)
+    def initialize(options: nil, transport_class: SubprocessCLITransport, transport_args: {})
       @options = options || ClaudeAgentOptions.new
+      @transport_class = transport_class
+      @transport_args = transport_args
       @transport = nil
       @query_handler = nil
       @connected = false
@@ -274,7 +280,7 @@ module ClaudeAgentSDK
       )
 
       # Client always uses streaming mode; keep stdin open for bidirectional communication.
-      @transport = SubprocessCLITransport.new(configured_options)
+      @transport = @transport_class.new(configured_options, **@transport_args)
       @transport.connect
 
       # Extract SDK MCP servers

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -205,15 +205,6 @@ RSpec.describe ClaudeAgentSDK::Client do
   end
 
   context 'with custom transport_class' do
-    let(:custom_transport) do
-      instance_double(ClaudeAgentSDK::Transport, connect: true, write: nil, close: nil, ready?: true)
-    end
-    let(:custom_transport_class) do
-      klass = Class.new(ClaudeAgentSDK::Transport)
-      transport_instance = custom_transport
-      klass.define_method(:initialize) { |_options| @instance = transport_instance }
-      klass
-    end
     let(:query_handler) do
       instance_double(ClaudeAgentSDK::Query, start: true, initialize_protocol: true, close: nil)
     end
@@ -222,10 +213,11 @@ RSpec.describe ClaudeAgentSDK::Client do
       allow(ClaudeAgentSDK::Query).to receive(:new).and_return(query_handler)
     end
 
-    it 'uses custom transport_class instead of SubprocessCLITransport' do
-      received_args = nil
-      klass = Class.new(ClaudeAgentSDK::Transport) do
-        define_method(:initialize) { |options, **kwargs| received_args = { options: options, kwargs: kwargs } }
+    # Build an anonymous Transport subclass that captures its initialize arguments
+    # via the provided block and stubs all interface methods.
+    def build_transport_class(&on_initialize)
+      Class.new(ClaudeAgentSDK::Transport) do
+        define_method(:initialize, &on_initialize)
         define_method(:connect) { nil }
         define_method(:write) { |_data| nil }
         define_method(:read_messages) { nil }
@@ -233,6 +225,11 @@ RSpec.describe ClaudeAgentSDK::Client do
         define_method(:ready?) { true }
         define_method(:end_input) { nil }
       end
+    end
+
+    it 'uses custom transport_class instead of SubprocessCLITransport' do
+      received_args = nil
+      klass = build_transport_class { |options, **kwargs| received_args = { options: options, kwargs: kwargs } }
 
       client = described_class.new(transport_class: klass)
       client.connect
@@ -243,15 +240,7 @@ RSpec.describe ClaudeAgentSDK::Client do
 
     it 'passes transport_args as keyword arguments to transport_class.new' do
       received_args = nil
-      klass = Class.new(ClaudeAgentSDK::Transport) do
-        define_method(:initialize) { |options, **kwargs| received_args = { options: options, kwargs: kwargs } }
-        define_method(:connect) { nil }
-        define_method(:write) { |_data| nil }
-        define_method(:read_messages) { nil }
-        define_method(:close) { nil }
-        define_method(:ready?) { true }
-        define_method(:end_input) { nil }
-      end
+      klass = build_transport_class { |options, **kwargs| received_args = { options: options, kwargs: kwargs } }
 
       client = described_class.new(
         transport_class: klass,
@@ -264,15 +253,7 @@ RSpec.describe ClaudeAgentSDK::Client do
 
     it 'still performs option transformations with custom transport' do
       received_options = nil
-      klass = Class.new(ClaudeAgentSDK::Transport) do
-        define_method(:initialize) { |options, **_kwargs| received_options = options }
-        define_method(:connect) { nil }
-        define_method(:write) { |_data| nil }
-        define_method(:read_messages) { nil }
-        define_method(:close) { nil }
-        define_method(:ready?) { true }
-        define_method(:end_input) { nil }
-      end
+      klass = build_transport_class { |options, **_kwargs| received_options = options }
 
       callback = ->(_tool_name, _input, _context) { ClaudeAgentSDK::PermissionResultAllow.new }
       options = ClaudeAgentSDK::ClaudeAgentOptions.new(can_use_tool: callback)

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -204,6 +204,96 @@ RSpec.describe ClaudeAgentSDK::Client do
     expect(client.get_server_info).to eq({ commands: ['help'] })
   end
 
+  context 'with custom transport_class' do
+    let(:custom_transport) do
+      instance_double(ClaudeAgentSDK::Transport, connect: true, write: nil, close: nil, ready?: true)
+    end
+    let(:custom_transport_class) do
+      klass = Class.new(ClaudeAgentSDK::Transport)
+      transport_instance = custom_transport
+      klass.define_method(:initialize) { |_options| @instance = transport_instance }
+      klass
+    end
+    let(:query_handler) do
+      instance_double(ClaudeAgentSDK::Query, start: true, initialize_protocol: true, close: nil)
+    end
+
+    before do
+      allow(ClaudeAgentSDK::Query).to receive(:new).and_return(query_handler)
+    end
+
+    it 'uses custom transport_class instead of SubprocessCLITransport' do
+      received_args = nil
+      klass = Class.new(ClaudeAgentSDK::Transport) do
+        define_method(:initialize) { |options, **kwargs| received_args = { options: options, kwargs: kwargs } }
+        define_method(:connect) { nil }
+        define_method(:write) { |_data| nil }
+        define_method(:read_messages) { nil }
+        define_method(:close) { nil }
+        define_method(:ready?) { true }
+        define_method(:end_input) { nil }
+      end
+
+      client = described_class.new(transport_class: klass)
+      client.connect
+
+      expect(received_args[:options]).to be_a(ClaudeAgentSDK::ClaudeAgentOptions)
+      expect(received_args[:kwargs]).to eq({})
+    end
+
+    it 'passes transport_args as keyword arguments to transport_class.new' do
+      received_args = nil
+      klass = Class.new(ClaudeAgentSDK::Transport) do
+        define_method(:initialize) { |options, **kwargs| received_args = { options: options, kwargs: kwargs } }
+        define_method(:connect) { nil }
+        define_method(:write) { |_data| nil }
+        define_method(:read_messages) { nil }
+        define_method(:close) { nil }
+        define_method(:ready?) { true }
+        define_method(:end_input) { nil }
+      end
+
+      client = described_class.new(
+        transport_class: klass,
+        transport_args: { sandbox: 'my-sandbox', timeout: 30 }
+      )
+      client.connect
+
+      expect(received_args[:kwargs]).to eq({ sandbox: 'my-sandbox', timeout: 30 })
+    end
+
+    it 'still performs option transformations with custom transport' do
+      received_options = nil
+      klass = Class.new(ClaudeAgentSDK::Transport) do
+        define_method(:initialize) { |options, **_kwargs| received_options = options }
+        define_method(:connect) { nil }
+        define_method(:write) { |_data| nil }
+        define_method(:read_messages) { nil }
+        define_method(:close) { nil }
+        define_method(:ready?) { true }
+        define_method(:end_input) { nil }
+      end
+
+      callback = ->(_tool_name, _input, _context) { ClaudeAgentSDK::PermissionResultAllow.new }
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(can_use_tool: callback)
+      client = described_class.new(options: options, transport_class: klass)
+      client.connect
+
+      expect(received_options.permission_prompt_tool_name).to eq('stdio')
+      expect(received_options.env['CLAUDE_CODE_ENTRYPOINT']).to eq('sdk-rb-client')
+    end
+
+    it 'defaults transport_class to SubprocessCLITransport' do
+      transport = instance_double(ClaudeAgentSDK::SubprocessCLITransport, connect: true, write: nil)
+      allow(ClaudeAgentSDK::SubprocessCLITransport).to receive(:new).and_return(transport)
+
+      client = described_class.new
+      client.connect
+
+      expect(ClaudeAgentSDK::SubprocessCLITransport).to have_received(:new)
+    end
+  end
+
   context 'with default configuration' do
     after { ClaudeAgentSDK.reset_configuration }
 


### PR DESCRIPTION
## Summary
- Add `transport_class` and `transport_args` keyword arguments to `Client#initialize`
- Default remains `SubprocessCLITransport` — zero behavior change for existing callers
- All option transformations, MCP extraction, hook conversion, and Query lifecycle stay in `Client#connect` — the transport only handles I/O

## Motivation
Consumers like Voyager's `E2BSandboxClient` currently duplicate ~50 lines of `Client#connect` internals to use a custom transport. This breaks silently when SDK internals change. With this PR, they can pass `transport_class: E2BSandboxTransport, transport_args: { sandbox: sandbox }` and get the full connect sequence for free.

## Test plan
- [x] 4 new specs covering custom transport class, transport_args passthrough, option transformations with custom transport, and default fallback
- [x] All 369 unit tests pass
- [x] RuboCop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)