### PR TITLE
Fix 8 bugs found in multi-angle code review

### DIFF
--- a/lib/claude_agent_sdk/query.rb
+++ b/lib/claude_agent_sdk/query.rb
@@ -162,14 +162,17 @@ module ClaudeAgentSDK
           handle_control_response(message)
         when 'control_request'
           request_id = message[:request_id] || message[:requestId]
-          task = Async do
+          # Spawn as a child of the current task so @task.stop cascades and
+          # nothing keeps running after close; bare Async do may root at the
+          # reactor and leak past shutdown.
+          handler_task = Async::Task.current.async do
             begin
               handle_control_request(message)
             ensure
               @inflight_control_request_tasks.delete(request_id) if request_id
             end
           end
-          @inflight_control_request_tasks[request_id] = task if request_id
+          @inflight_control_request_tasks[request_id] = handler_task if request_id
         when 'control_cancel_request'
           request_id = message[:request_id] || message[:requestId]
           task = request_id ? @inflight_control_request_tasks[request_id] : nil

--- a/lib/claude_agent_sdk/session_mutations.rb
+++ b/lib/claude_agent_sdk/session_mutations.rb
@@ -413,7 +413,7 @@ module ClaudeAgentSDK
 
     private_class_method :find_session_file_with_dir,
                          :find_in_directory, :try_project_dir, :find_in_all_projects,
-                         :parse_fork_transcript, :build_forked_entry, :resolve_parent_uuid,
+                         :parse_fork_transcript, :derive_fork_title, :build_forked_entry, :resolve_parent_uuid,
                          :append_to_session, :append_to_session_in_directory,
                          :append_to_session_global, :try_append, :sanitize_unicode, :unicode_category
   end

--- a/lib/claude_agent_sdk/session_mutations.rb
+++ b/lib/claude_agent_sdk/session_mutations.rb
@@ -108,10 +108,10 @@ module ClaudeAgentSDK
       raise Errno::ENOENT, "Session #{session_id} not found#{" in project directory for #{directory}" if directory}" unless result
 
       file_path, project_dir = result
-      content = File.read(file_path)
-      raise ArgumentError, "Session #{session_id} has no messages to fork" if content.empty?
+      file_size = File.size(file_path)
+      raise ArgumentError, "Session #{session_id} has no messages to fork" if file_size.zero?
 
-      transcript, content_replacements = parse_fork_transcript(content, session_id)
+      transcript, content_replacements = parse_fork_transcript(file_path)
       transcript.reject! { |e| e['isSidechain'] }
       raise ArgumentError, "Session #{session_id} has no messages to fork" if transcript.empty?
 
@@ -149,19 +149,9 @@ module ClaudeAgentSDK
                                })
       end
 
-      # Derive title
+      # Derive title — only read head/tail chunks when we need to generate one
       fork_title = title&.strip
-      if fork_title.nil? || fork_title.empty?
-        head = content[0, Sessions::LITE_READ_BUF_SIZE] || ''
-        tail = content.length > Sessions::LITE_READ_BUF_SIZE ? content[-Sessions::LITE_READ_BUF_SIZE..] : head
-        base = Sessions.extract_json_string_field(tail, 'customTitle', last: true) ||
-               Sessions.extract_json_string_field(head, 'customTitle', last: true) ||
-               Sessions.extract_json_string_field(tail, 'aiTitle', last: true) ||
-               Sessions.extract_json_string_field(head, 'aiTitle', last: true) ||
-               Sessions.extract_first_prompt_from_head(head) ||
-               'Forked session'
-        fork_title = "#{base} (fork)"
-      end
+      fork_title = "#{derive_fork_title(file_path, file_size)} (fork)" if fork_title.nil? || fork_title.empty?
 
       lines << JSON.generate({
                                'type' => 'custom-title',
@@ -236,13 +226,20 @@ module ClaudeAgentSDK
       nil
     end
 
-    # Parse a fork transcript, extracting entries and content-replacement data.
-    def parse_fork_transcript(content, _session_id)
+    # Parse a fork transcript by streaming the JSONL file line-by-line.
+    # Opens in binary mode and scrubs invalid UTF-8 so stray non-UTF-8
+    # bytes in tool results do not raise Encoding::InvalidByteSequenceError.
+    def parse_fork_transcript(file_path)
       transcript = []
       content_replacements = nil
 
-      content.each_line do |line|
-        entry = JSON.parse(line.strip)
+      File.foreach(file_path, mode: 'rb') do |line|
+        line = line.force_encoding('UTF-8').scrub
+        begin
+          entry = JSON.parse(line.strip)
+        rescue JSON::ParserError
+          next
+        end
         next unless entry.is_a?(Hash) && entry['uuid']
 
         if entry['type'] == 'content-replacement'
@@ -250,11 +247,31 @@ module ClaudeAgentSDK
           next
         end
         transcript << entry
-      rescue JSON::ParserError
-        next
       end
 
       [transcript, content_replacements]
+    end
+
+    # Derive a fork title from the source file's head/tail chunks without
+    # slurping the entire file. Matches the lookup order used for
+    # SDKSessionInfo.custom_title / ai_title / first_prompt.
+    def derive_fork_title(file_path, file_size)
+      buf_size = [Sessions::LITE_READ_BUF_SIZE, file_size].min
+      File.open(file_path, 'rb') do |f|
+        head = (f.read(buf_size) || '').force_encoding('UTF-8').scrub
+        tail = if file_size > Sessions::LITE_READ_BUF_SIZE
+                 f.seek(-buf_size, IO::SEEK_END)
+                 (f.read(buf_size) || '').force_encoding('UTF-8').scrub
+               else
+                 head
+               end
+        Sessions.extract_json_string_field(tail, 'customTitle', last: true) ||
+          Sessions.extract_json_string_field(head, 'customTitle', last: true) ||
+          Sessions.extract_json_string_field(tail, 'aiTitle', last: true) ||
+          Sessions.extract_json_string_field(head, 'aiTitle', last: true) ||
+          Sessions.extract_first_prompt_from_head(head) ||
+          'Forked session'
+      end
     end
 
     # Build a single forked entry with remapped UUIDs.

--- a/lib/claude_agent_sdk/sessions.rb
+++ b/lib/claude_agent_sdk/sessions.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
-require 'English'
 require 'json'
+require 'open3'
 require 'pathname'
-require 'shellwords'
 
 module ClaudeAgentSDK
   # Session info returned by list_sessions
@@ -442,8 +441,8 @@ module ClaudeAgentSDK
     end
 
     def detect_worktrees(path)
-      output = `git -C #{Shellwords.escape(path)} worktree list --porcelain 2>/dev/null`
-      return [path] unless $CHILD_STATUS.success?
+      output, _err, status = Open3.capture3('git', '-C', path, 'worktree', 'list', '--porcelain')
+      return [path] unless status.success?
 
       paths = output.lines.filter_map do |line|
         line.strip.delete_prefix('worktree ') if line.start_with?('worktree ')

--- a/lib/claude_agent_sdk/sessions.rb
+++ b/lib/claude_agent_sdk/sessions.rb
@@ -306,6 +306,7 @@ module ClaudeAgentSDK
     # @param include_worktrees [Boolean] Whether to include git worktree sessions
     # @return [Array<SDKSessionInfo>] Sessions sorted by last_modified descending
     def list_sessions(directory: nil, limit: nil, offset: 0, include_worktrees: true)
+      offset ||= 0
       sessions = if directory
                    list_sessions_for_directory(directory, include_worktrees)
                  else
@@ -353,6 +354,8 @@ module ClaudeAgentSDK
     # @return [Array<SessionMessage>] Ordered messages from the session
     def get_session_messages(session_id:, directory: nil, limit: nil, offset: 0)
       return [] unless session_id.match?(UUID_RE)
+
+      offset ||= 0
 
       file_path = find_session_file(session_id, directory)
       return [] unless file_path && File.exist?(file_path)

--- a/lib/claude_agent_sdk/sessions.rb
+++ b/lib/claude_agent_sdk/sessions.rb
@@ -58,11 +58,13 @@ module ClaudeAgentSDK
 
     module_function
 
-    # Match TypeScript's simpleHash: signed 32-bit integer, base-36 output
+    # Match TypeScript's simpleHash: signed 32-bit integer, base-36 output.
+    # JS's charCodeAt returns UTF-16 code units, so supplementary characters
+    # (emoji, CJK extensions) emit two surrogate code units — iterate over
+    # UTF-16LE shorts instead of Unicode codepoints to preserve parity.
     def simple_hash(str)
       h = 0
-      str.each_char do |ch|
-        char_code = ch.ord
+      str.encode('UTF-16LE').unpack('v*').each do |char_code|
         h = ((h << 5) - h + char_code) & 0xFFFFFFFF
         h -= 0x100000000 if h >= 0x80000000
       end

--- a/lib/claude_agent_sdk/subprocess_cli_transport.rb
+++ b/lib/claude_agent_sdk/subprocess_cli_transport.rb
@@ -12,6 +12,7 @@ module ClaudeAgentSDK
   class SubprocessCLITransport < Transport
     DEFAULT_MAX_BUFFER_SIZE = 1024 * 1024 # 1MB buffer limit
     MINIMUM_CLAUDE_CODE_VERSION = '2.0.0'
+    EXTRA_ARG_FLAG_RE = /\A[a-z0-9][a-z0-9-]*\z/
 
     def initialize(options_or_prompt = nil, options = nil)
       # Support both new single-arg form and legacy two-arg form
@@ -166,10 +167,15 @@ module ClaudeAgentSDK
 
       # Extra args
       @options.extra_args.each do |flag, value|
+        flag_str = flag.to_s
+        unless EXTRA_ARG_FLAG_RE.match?(flag_str)
+          raise ArgumentError, "Invalid extra_args flag name: #{flag.inspect} (expected lowercase kebab-case)"
+        end
+
         if value.nil?
-          cmd << "--#{flag}"
+          cmd << "--#{flag_str}"
         else
-          cmd.concat(["--#{flag}", value.to_s])
+          cmd.concat(["--#{flag_str}", value.to_s])
         end
       end
 

--- a/lib/claude_agent_sdk/subprocess_cli_transport.rb
+++ b/lib/claude_agent_sdk/subprocess_cli_transport.rb
@@ -160,8 +160,9 @@ module ClaudeAgentSDK
       build_plugins_args(cmd)
 
       # Setting sources
-      sources_value = @options.setting_sources ? @options.setting_sources.join(',') : ''
-      cmd.concat(['--setting-sources', sources_value])
+      if @options.setting_sources
+        cmd.concat(['--setting-sources', @options.setting_sources.join(',')])
+      end
 
       # Extra args
       @options.extra_args.each do |flag, value|

--- a/lib/claude_agent_sdk/subprocess_cli_transport.rb
+++ b/lib/claude_agent_sdk/subprocess_cli_transport.rb
@@ -344,15 +344,12 @@ module ClaudeAgentSDK
       # EOF on stdin. Without this grace period, SIGTERM can interrupt the
       # write and cause the last assistant message to be lost.
       begin
-        if @process.alive?
-          # Give the process up to 5 seconds to exit on its own
-          Timeout.timeout(5) { @process.value }
-        end
+        wait_process_with_timeout(5) if @process.alive?
       rescue Timeout::Error
         # Graceful shutdown timed out — send SIGTERM
         begin
           Process.kill('TERM', @process.pid)
-          Timeout.timeout(2) { @process.value }
+          wait_process_with_timeout(2)
         rescue Timeout::Error
           # SIGTERM didn't work — force kill
           begin
@@ -381,6 +378,22 @@ module ClaudeAgentSDK
       @stderr = nil
       @stderr_task = nil
       @exit_error = nil
+    end
+
+    # Wait for the spawned process to exit, up to +timeout_seconds+. Polls
+    # @process.alive? rather than using stdlib Timeout.timeout, which raises
+    # across threads via Thread#raise and corrupts Async fiber-scheduler state
+    # (close is always called inside an Async task). Yields to the current
+    # Async task when one is active so the reactor keeps running.
+    def wait_process_with_timeout(timeout_seconds)
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout_seconds
+      task = defined?(Async::Task) ? Async::Task.current? : nil
+      while @process.alive?
+        raise Timeout::Error if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+
+        task ? task.sleep(0.05) : sleep(0.05)
+      end
+      @process.value
     end
 
     def write(data)

--- a/spec/unit/session_mutations_spec.rb
+++ b/spec/unit/session_mutations_spec.rb
@@ -237,6 +237,20 @@ RSpec.describe ClaudeAgentSDK::SessionMutations do
         .to raise_error(ArgumentError, /Invalid up_to_message_id/)
     end
 
+    it 'tolerates non-UTF-8 bytes in the session file' do
+      Dir.mktmpdir do |tmpdir|
+        entry = { 'type' => 'user', 'uuid' => msg1_uuid, 'parentUuid' => nil,
+                  'message' => { 'content' => 'hello' } }
+        # Embed an invalid UTF-8 byte (0xFF) alongside valid JSONL entries.
+        content = "#{JSON.generate(entry)}\n".b + "\xFF\n".b
+        setup_session(tmpdir, content)
+
+        expect do
+          described_class.fork_session(session_id: session_id, directory: tmpdir)
+        end.not_to raise_error
+      end
+    end
+
     it 'forks a session with UUID remapping' do
       Dir.mktmpdir do |tmpdir|
         content = build_session_content([

--- a/spec/unit/sessions_spec.rb
+++ b/spec/unit/sessions_spec.rb
@@ -351,6 +351,11 @@ RSpec.describe ClaudeAgentSDK::Sessions do
         expect(sessions.first.session_id).to eq(uuid_new)
       end
     end
+
+    it 'treats offset: nil the same as offset: 0' do
+      allow(described_class).to receive(:config_dir).and_return('/nonexistent')
+      expect { described_class.list_sessions(offset: nil) }.not_to raise_error
+    end
   end
 
   describe '.get_session_info' do
@@ -433,6 +438,16 @@ RSpec.describe ClaudeAgentSDK::Sessions do
     it 'returns empty when session file not found' do
       allow(described_class).to receive(:config_dir).and_return('/nonexistent')
       expect(described_class.get_session_messages(session_id: '12345678-1234-1234-1234-123456789abc')).to eq([])
+    end
+
+    it 'treats offset: nil the same as offset: 0' do
+      allow(described_class).to receive(:config_dir).and_return('/nonexistent')
+      expect do
+        described_class.get_session_messages(
+          session_id: '12345678-1234-1234-1234-123456789abc',
+          offset: nil
+        )
+      end.not_to raise_error
     end
 
     it 'parses a simple conversation' do

--- a/spec/unit/sessions_spec.rb
+++ b/spec/unit/sessions_spec.rb
@@ -23,6 +23,13 @@ RSpec.describe ClaudeAgentSDK::Sessions do
       expect(result).to be_a(String)
       expect(result.length).to be > 0
     end
+
+    it 'uses UTF-16 code units so supplementary chars match JS charCodeAt' do
+      # '😀' (U+1F600) encodes as UTF-16 surrogate pair D83D DE00 (55357, 56832).
+      # A codepoint-based implementation would hash the single value 128512 and
+      # produce a different result.
+      expect(described_class.simple_hash('😀')).to eq('11zz7')
+    end
   end
 
   describe '.sanitize_path' do

--- a/spec/unit/subprocess_cli_transport_spec.rb
+++ b/spec/unit/subprocess_cli_transport_spec.rb
@@ -64,6 +64,27 @@ RSpec.describe ClaudeAgentSDK::SubprocessCLITransport do
       expect(cmd).to include('--input-format', 'stream-json')
     end
 
+    it 'omits --setting-sources when setting_sources is nil' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(cli_path: '/usr/bin/claude')
+
+      transport = described_class.new('hi', options)
+      cmd = transport.build_command
+
+      expect(cmd).not_to include('--setting-sources')
+    end
+
+    it 'emits --setting-sources joined by commas when set' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(
+        cli_path: '/usr/bin/claude',
+        setting_sources: %w[user project]
+      )
+
+      transport = described_class.new('hi', options)
+      cmd = transport.build_command
+
+      expect(cmd).to include('--setting-sources', 'user,project')
+    end
+
     it 'does not include --agents in CLI args' do
       agent = ClaudeAgentSDK::AgentDefinition.new(
         description: 'Test agent',

--- a/spec/unit/subprocess_cli_transport_spec.rb
+++ b/spec/unit/subprocess_cli_transport_spec.rb
@@ -413,6 +413,30 @@ RSpec.describe ClaudeAgentSDK::SubprocessCLITransport do
     end
   end
 
+  describe '#wait_process_with_timeout' do
+    let(:options) { ClaudeAgentSDK::ClaudeAgentOptions.new(cli_path: '/usr/bin/claude') }
+    let(:transport) { described_class.new('hi', options) }
+
+    it 'returns the process value when the process exits within the timeout' do
+      process = double('Process::Waiter', pid: 1234)
+      allow(process).to receive(:alive?).and_return(true, false)
+      allow(process).to receive(:value).and_return(:exited)
+
+      transport.instance_variable_set(:@process, process)
+
+      expect(transport.send(:wait_process_with_timeout, 1)).to eq(:exited)
+    end
+
+    it 'raises Timeout::Error when the process stays alive past the deadline' do
+      process = double('Process::Waiter', pid: 1234)
+      allow(process).to receive(:alive?).and_return(true)
+
+      transport.instance_variable_set(:@process, process)
+
+      expect { transport.send(:wait_process_with_timeout, 0.1) }.to raise_error(Timeout::Error)
+    end
+  end
+
   describe 'environment variable handling' do
     it 'converts symbol keys in env to strings for spawn compatibility' do
       options = ClaudeAgentSDK::ClaudeAgentOptions.new(

--- a/spec/unit/subprocess_cli_transport_spec.rb
+++ b/spec/unit/subprocess_cli_transport_spec.rb
@@ -101,6 +101,41 @@ RSpec.describe ClaudeAgentSDK::SubprocessCLITransport do
       expect(cmd).not_to include('--agents')
     end
 
+    it 'passes valid extra_args flags as --flag value' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(
+        cli_path: '/usr/bin/claude',
+        extra_args: { 'debug-to-stderr' => nil, 'custom-flag' => 'value' }
+      )
+
+      transport = described_class.new('hi', options)
+      cmd = transport.build_command
+
+      expect(cmd).to include('--debug-to-stderr')
+      expect(cmd).to include('--custom-flag', 'value')
+    end
+
+    it 'rejects extra_args keys that contain spaces or invalid characters' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(
+        cli_path: '/usr/bin/claude',
+        extra_args: { 'permission-mode bypassPermissions' => nil }
+      )
+
+      transport = described_class.new('hi', options)
+
+      expect { transport.build_command }.to raise_error(ArgumentError, /Invalid extra_args flag name/)
+    end
+
+    it 'rejects extra_args keys that are empty or start with --' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(
+        cli_path: '/usr/bin/claude',
+        extra_args: { '--permission-mode' => 'bypassPermissions' }
+      )
+
+      transport = described_class.new('hi', options)
+
+      expect { transport.build_command }.to raise_error(ArgumentError, /Invalid extra_args flag name/)
+    end
+
     it 'passes --thinking adaptive for ThinkingConfigAdaptive' do
       options = ClaudeAgentSDK::ClaudeAgentOptions.new(
         cli_path: '/usr/bin/claude',


### PR DESCRIPTION
## Summary

Fixes from a multi-angle review of the SDK (concurrency, protocol, security, API logic, sessions). Each fix is its own commit with regression tests. Baseline 526 → 537 specs, 0 failures, RuboCop clean.

## Fixes

| # | Commit | Scope |
|---|--------|-------|
| 1 | `a3cbbff` | Only emit `--setting-sources` when set — previously leaked `--setting-sources ""` to every CLI invocation, overriding the CLI's default source resolution |
| 2 | `45bc6f4` | Coerce `offset: nil` to 0 in `list_sessions` / `get_session_messages` — `nil.positive?` and `messages[nil..]` crashed callers splatting from options hashes |
| 3 | `62ecf78` | Replace shell backticks with `Open3.capture3` in worktree detection — removes latent shell-injection surface (future interpolation would be exploitable) |
| 4 | `31c574a` | Validate `extra_args` flag names — an attacker controlling that hash (multi-tenant config) could inject `--permission-mode bypassPermissions` and rely on CLI last-wins to defeat SDK-chosen safety |
| 5 | `07b9e31` | `simple_hash` iterates UTF-16 code units — `ch.ord` returned codepoints while the TS implementation returned UTF-16 units, so supplementary chars (emoji, CJK extensions) hashed to different project dirs than the official tools |
| 6 | `c5bedad` | Stream `fork_session` transcript and scrub non-UTF-8 — `File.read` slurped the entire JSONL (sessions reach hundreds of MB) and raised `Encoding::InvalidByteSequenceError` on stray bytes in tool output |
| 7 | `eb5f29e` | Replace `Timeout.timeout` with Async-safe polling in transport `close` — stdlib `Timeout.timeout` raises via `Thread#raise`, which can corrupt fiber-scheduler state when `close` runs inside the Async reactor |
| 8 | `0ed8578` | Spawn `control_request` handlers as children of the current task — bare `Async do` had ambiguous parent linkage; `@task.stop` could leave handler tasks running past shutdown, writing to a closed transport |

## Not included (discussed, deferred)

- `--system-prompt-file` path validation — needs an API-level base-dir scheme before it can be a single-commit fix
- OTel observer redaction — additive feature, not a bug
- `suppress_output: false` / `interrupt: false` serialization — correct as long as the CLI's default matches; "fixing" without wire-format certainty risks silent parity regressions

## Test plan

- [x] Baseline green pre-branch (526 examples, 0 failures)
- [x] `bundle exec rspec` after each commit individually
- [x] `bundle exec rubocop` clean on every touched file
- [x] `bundle exec rake` (spec + rubocop) on the final branch — 537 examples, 0 failures
- [x] New regression specs added for fixes #1, #2, #4, #5, #6, #7 (11 new examples)
- [ ] Manual smoke test with a real Claude Code CLI session (integration specs) before merge
- [ ] Verify no behavioral change to \`--setting-sources\` when the user explicitly passes an empty array (current code would send \`--setting-sources ""\` — confirm that's still acceptable or decide if it should be omitted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)