### PR TITLE
feat(effort): add xhigh level and export EFFORT_LEVELS constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **`EFFORT_LEVELS` constant** exposing `%w[low medium high xhigh max]`. Consumers can reference `ClaudeAgentSDK::EFFORT_LEVELS` for validation instead of hard-coding the list.
+- **`xhigh` effort level**: documented in the SDK to match the Claude Code CLI (2.1.111+). Supported on Opus 4.7; the CLI auto-falls-back to the highest supported level on older models (e.g. `xhigh` → `high` on Opus 4.6).
+
+### Changed
+- Inline comments and README updated to reference `ClaudeAgentSDK::EFFORT_LEVELS` rather than a stale hard-coded level list.
+
 ## [0.14.1] - 2026-04-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -744,9 +744,11 @@ Use the `effort` option to control the model's effort level:
 
 ```ruby
 options = ClaudeAgentSDK::ClaudeAgentOptions.new(
-  effort: 'high'  # 'low', 'medium', or 'high'
+  effort: 'xhigh'  # see ClaudeAgentSDK::EFFORT_LEVELS
 )
 ```
+
+Valid levels live in `ClaudeAgentSDK::EFFORT_LEVELS` (`low`, `medium`, `high`, `xhigh`, `max`). The set of *supported* levels is model-dependent — `xhigh` is available on Opus 4.7 and the CLI falls back to the highest supported level at or below the one you set (e.g. `xhigh` → `high` on Opus 4.6). When `effort` is `nil`, the CLI picks a model-native default (Opus 4.7 → `xhigh`).
 
 > **Note:** When `system_prompt` is `nil` (the default), the SDK passes `--system-prompt ""` to the CLI, which suppresses the default Claude Code system prompt. To use the default system prompt, use a `SystemPromptPreset`.
 

--- a/lib/claude_agent_sdk/subprocess_cli_transport.rb
+++ b/lib/claude_agent_sdk/subprocess_cli_transport.rb
@@ -122,7 +122,9 @@ module ClaudeAgentSDK
       # Thinking configuration (takes precedence over deprecated max_thinking_tokens)
       build_thinking_args(cmd)
 
-      # Effort level (valid values: low, medium, high, max)
+      # Effort level — see ClaudeAgentSDK::EFFORT_LEVELS. The set of supported
+      # levels is model-dependent; the CLI falls back to the highest supported
+      # level at or below the one requested (e.g. `xhigh` → `high` on Opus 4.6).
       cmd.concat(['--effort', @options.effort.to_s]) if @options.effort
 
       # Betas option for enabling experimental features

--- a/lib/claude_agent_sdk/types.rb
+++ b/lib/claude_agent_sdk/types.rb
@@ -7,6 +7,12 @@ module ClaudeAgentSDK
   # Type constants for setting sources
   SETTING_SOURCES = %w[user project local].freeze
 
+  # Effort levels for `ClaudeAgentOptions#effort`. The CLI (Claude Code 2.1.111+)
+  # accepts these values; the set of *supported* levels is model-dependent
+  # (e.g. `xhigh` is only supported on Opus 4.7 and falls back to `high` on
+  # Opus 4.6 / Sonnet 4.6). An Integer is also accepted and forwarded verbatim.
+  EFFORT_LEVELS = %w[low medium high xhigh max].freeze
+
   # Type constants for permission update destinations
   PERMISSION_UPDATE_DESTINATIONS = %w[userSettings projectSettings localSettings session].freeze
 
@@ -620,7 +626,7 @@ module ClaudeAgentSDK
       @initial_prompt = initial_prompt # Initial prompt sent when agent starts
       @max_turns = max_turns # Maximum conversation turns for the agent
       @background = background # Whether this agent runs in background
-      @effort = effort # "low", "medium", "high", "max", or Integer
+      @effort = effort # See ClaudeAgentSDK::EFFORT_LEVELS or an Integer
       @permission_mode = permission_mode # Permission mode for the agent
     end
   end

--- a/plugins/claude-agent-ruby/skills/claude-agent-ruby/references/usage-map.md
+++ b/plugins/claude-agent-ruby/skills/claude-agent-ruby/references/usage-map.md
@@ -111,8 +111,9 @@ options = ClaudeAgentSDK::ClaudeAgentOptions.new(
   thinking: ClaudeAgentSDK::ThinkingConfigEnabled.new(budget_tokens: 10_000)
 )
 
-# Effort level
-options = ClaudeAgentSDK::ClaudeAgentOptions.new(effort: 'high')
+# Effort level — see ClaudeAgentSDK::EFFORT_LEVELS
+# ('low', 'medium', 'high', 'xhigh', 'max'; model-dependent)
+options = ClaudeAgentSDK::ClaudeAgentOptions.new(effort: 'xhigh')
 ```
 
 Full sandbox configuration:

--- a/skills/references/usage-map.md
+++ b/skills/references/usage-map.md
@@ -111,8 +111,9 @@ options = ClaudeAgentSDK::ClaudeAgentOptions.new(
   thinking: ClaudeAgentSDK::ThinkingConfigEnabled.new(budget_tokens: 10_000)
 )
 
-# Effort level
-options = ClaudeAgentSDK::ClaudeAgentOptions.new(effort: 'high')
+# Effort level — see ClaudeAgentSDK::EFFORT_LEVELS
+# ('low', 'medium', 'high', 'xhigh', 'max'; model-dependent)
+options = ClaudeAgentSDK::ClaudeAgentOptions.new(effort: 'xhigh')
 ```
 
 Full sandbox configuration:

--- a/spec/unit/subprocess_cli_transport_spec.rb
+++ b/spec/unit/subprocess_cli_transport_spec.rb
@@ -179,6 +179,30 @@ RSpec.describe ClaudeAgentSDK::SubprocessCLITransport do
       expect(cmd).to include('--effort', 'max')
     end
 
+    it 'passes --effort xhigh' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(
+        cli_path: '/usr/bin/claude',
+        effort: 'xhigh'
+      )
+
+      transport = described_class.new('hi', options)
+      cmd = transport.build_command
+
+      expect(cmd).to include('--effort', 'xhigh')
+    end
+
+    it 'omits --effort when effort is nil' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(
+        cli_path: '/usr/bin/claude',
+        effort: nil
+      )
+
+      transport = described_class.new('hi', options)
+      cmd = transport.build_command
+
+      expect(cmd).not_to include('--effort')
+    end
+
     it 'maps tools preset objects to the CLI default tool set' do
       options = ClaudeAgentSDK::ClaudeAgentOptions.new(
         cli_path: '/usr/bin/claude',

--- a/spec/unit/types_spec.rb
+++ b/spec/unit/types_spec.rb
@@ -3,6 +3,13 @@
 require 'spec_helper'
 
 RSpec.describe ClaudeAgentSDK do
+  describe 'Module constants' do
+    it 'exposes EFFORT_LEVELS' do
+      expect(ClaudeAgentSDK::EFFORT_LEVELS).to eq(%w[low medium high xhigh max])
+      expect(ClaudeAgentSDK::EFFORT_LEVELS).to be_frozen
+    end
+  end
+
   describe 'Type Classes' do
     describe ClaudeAgentSDK::TextBlock do
       it 'stores text content' do
@@ -1410,6 +1417,11 @@ RSpec.describe ClaudeAgentSDK do
       it 'accepts effort option' do
         options = ClaudeAgentSDK::ClaudeAgentOptions.new(effort: 'high')
         expect(options.effort).to eq('high')
+      end
+
+      it 'accepts xhigh effort level' do
+        options = ClaudeAgentSDK::ClaudeAgentOptions.new(effort: 'xhigh')
+        expect(options.effort).to eq('xhigh')
       end
 
       it 'accepts bare option' do


### PR DESCRIPTION
## Summary

Bring the Ruby SDK's \`effort\` level support up to date with Claude Code CLI 2.1.111+, which introduced \`xhigh\` (the default on Opus 4.7). Also export the canonical level list as a module constant so downstream apps can validate input without hard-coding it.

## Background

The CLI now accepts five effort levels: \`low\`, \`medium\`, \`high\`, \`xhigh\`, \`max\`. The \`xhigh\` level is only *supported* on Opus 4.7; on older models (Opus 4.6, Sonnet 4.6) the CLI auto-falls-back to the highest level at or below the one requested (so \`xhigh\` → \`high\`). The SDK's transport already passes the value through verbatim, so no runtime code changes are needed — but the docs/comments/tests referenced only the 4-level list.

Source: https://code.claude.com/docs/en/model-config#adjust-effort-level

## Changes

- **\`lib/claude_agent_sdk/types.rb\`** — add \`ClaudeAgentSDK::EFFORT_LEVELS = %w[low medium high xhigh max].freeze\` alongside \`PERMISSION_MODES\`. Update \`@effort\` comment to reference the constant.
- **\`lib/claude_agent_sdk/subprocess_cli_transport.rb\`** — update inline comment to reference the constant and document model-dependent fallback.
- **\`README.md\`** — change example to \`effort: 'xhigh'\`; add a paragraph explaining the constant and model-dependent fallback behavior, and call out the model-native default (Opus 4.7 → \`xhigh\`) for the \`nil\` case.
- **\`skills/references/usage-map.md\`** and **\`plugins/claude-agent-ruby/skills/claude-agent-ruby/references/usage-map.md\`** — same example update.
- **Specs** — add coverage for:
  - \`--effort xhigh\` being forwarded to the CLI
  - \`--effort\` being omitted when \`effort\` is \`nil\` (pins current behavior)
  - \`EFFORT_LEVELS\` contents and frozen-ness
  - \`ClaudeAgentOptions.new(effort: 'xhigh')\` round-tripping
- **CHANGELOG** — entry under \`[Unreleased]\`.

## Test plan

- [x] \`bundle exec rspec\` — 530 examples, 0 failures
- [x] \`rubocop\` clean on all touched files

## Why no runtime change

\`subprocess_cli_transport.rb\` already does \`cmd.concat(['--effort', @options.effort.to_s]) if @options.effort\` — the value is forwarded as-is. So the SDK was already compatible with \`xhigh\` at runtime; this PR closes the documentation/test gap and exposes the constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)