### PR TITLE
test(effort): pin Integer effort pass-through contract

### DIFF
--- a/spec/unit/subprocess_cli_transport_spec.rb
+++ b/spec/unit/subprocess_cli_transport_spec.rb
@@ -203,6 +203,18 @@ RSpec.describe ClaudeAgentSDK::SubprocessCLITransport do
       expect(cmd).not_to include('--effort')
     end
 
+    it 'forwards an Integer effort verbatim' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(
+        cli_path: '/usr/bin/claude',
+        effort: 8000
+      )
+
+      transport = described_class.new('hi', options)
+      cmd = transport.build_command
+
+      expect(cmd).to include('--effort', '8000')
+    end
+
     it 'maps tools preset objects to the CLI default tool set' do
       options = ClaudeAgentSDK::ClaudeAgentOptions.new(
         cli_path: '/usr/bin/claude',


### PR DESCRIPTION
PR #20 documented that `effort` accepts an Integer that the transport
forwards verbatim (`@options.effort.to_s`), but no spec exercised that
path. This adds one so the contract is protected against future
validation work that might accidentally reject non-String values.

https://claude.ai/code/session_01H2C2nT3fAVV29ZbpCFqRMg