### PR TITLE
fix(async): contain Fiber scheduler inside the SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Thread-keyed libraries are now safe inside SDK callbacks.** The SDK internally hops to a plain thread at every user-callback boundary — blocks passed to `ClaudeAgentSDK.query` / `Client#receive_messages`, SDK MCP tool handlers, hooks, permission callbacks, and observer methods — so the `async` gem's Fiber scheduler is no longer visible to user code. Previously, any library that keys state on `Thread.current` (ActiveRecord and every DB driver keyed by thread — `pg`, `mysql2`, `sqlite3` — plus per-thread HTTP/cache pools, request stores, etc.) could be corrupted by the scheduler interleaving two fibers onto one checked-out connection. Rails/Sidekiq/Kamal consumers no longer need a caller-side wrapper to avoid this. See the "Thread-keyed libraries are safe inside SDK callbacks" subsection under Rails Integration in the README.
+
+### Changed
+- **Callbacks run on a plain thread, not inside `Async::Task`.** Fiber-specific primitives (e.g. `Async::Task.current.sleep`, `Async::Task.current.async { ... }`) are no longer available inside tool handlers, hooks, permission callbacks, message blocks, or observers. Callbacks that want cooperative concurrency can open their own `Async { }` block. In practice callbacks do ordinary Ruby work and return a value, so this rarely affects real code.
+
 ## [0.15.0] - 2026-04-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1194,6 +1194,45 @@ For a complete multi-tool example, see [examples/otel_langfuse_example.rb](examp
 
 The SDK integrates well with Rails applications. Here are common patterns:
 
+### Thread-keyed libraries are safe inside SDK callbacks
+
+The SDK depends on [`async`](https://github.com/socketry/async), which installs
+a Fiber scheduler that multiplexes fibers onto a single OS thread and
+intercepts IO so blocking calls yield to siblings. Most mature Ruby libraries
+are thread-safe but not fiber-safe — they key state (checked-out DB
+connections, per-thread caches, request stores) on `Thread.current`. When the
+scheduler interleaves two fibers on one thread, those fibers share the same
+state slot, and interleaved IO on a shared connection silently corrupts wire
+protocols. This affects every DB driver keyed by thread (`pg`, `mysql2`,
+`sqlite3`), ActiveRecord's connection pool, and HTTP/cache clients pooled per
+thread.
+
+You do **not** need to think about this. The SDK hops to a plain thread at
+every user-callback boundary — message blocks given to `query` / `Client`, SDK
+MCP tool handlers, hooks, permission callbacks, and observer methods — so
+your code runs with no Fiber scheduler active and inherits the ordinary
+thread-keyed assumptions every Rails / Sidekiq / Kamal app already makes:
+
+```ruby
+tool = ClaudeAgentSDK.create_tool('lookup_user', 'Look up a user', { id: Integer }) do |args|
+  user = User.find(args[:id])                # just works
+  { content: [{ type: 'text', text: user.name }] }
+end
+
+ClaudeAgentSDK.query(prompt: '...') do |message|
+  Message.create!(role: 'assistant', body: message.to_s)   # just works
+end
+```
+
+The trade-off: because callbacks run on a plain thread rather than inside
+an `Async::Task`, fiber-specific primitives aren't available to them —
+`Async::Task.current` will raise "No async task available". If a callback
+wants cooperative concurrency it should open its own `Async { }` block. In
+practice, callbacks typically do some Ruby work, call external services, and
+return — so this rarely matters. If you wrap your own call site in an outer
+`Async { }` block, the scheduler is visible to your code again; you've opted
+in, and whatever fiber-safety rules your app uses apply there.
+
 ### ActionCable Streaming
 
 Stream Claude responses to the frontend in real-time:

--- a/lib/claude_agent_sdk.rb
+++ b/lib/claude_agent_sdk.rb
@@ -13,6 +13,7 @@ require_relative 'claude_agent_sdk/sdk_mcp_server'
 require_relative 'claude_agent_sdk/streaming'
 require_relative 'claude_agent_sdk/sessions'
 require_relative 'claude_agent_sdk/session_mutations'
+require_relative 'claude_agent_sdk/fiber_boundary'
 require 'async'
 require 'securerandom'
 
@@ -28,9 +29,12 @@ module ClaudeAgentSDK
   end
 
   # Safely call a method on each observer, suppressing any errors.
+  # Each observer is invoked through FiberBoundary so that user code runs
+  # on a plain thread (no Fiber scheduler) even when called from inside
+  # the SDK's Async reactor.
   def self.notify_observers(observers, method, *args)
     observers.each do |obs|
-      obs.send(method, *args)
+      FiberBoundary.invoke { obs.send(method, *args) }
     rescue StandardError
       nil
     end
@@ -230,12 +234,14 @@ module ClaudeAgentSDK
           end
         end
 
-        # Read and yield messages from the query handler (filters out control messages)
+        # Read and yield messages from the query handler (filters out control messages).
+        # User block is invoked through FiberBoundary so ActiveRecord / PG calls
+        # inside it don't see the async gem's Fiber scheduler.
         query_handler.receive_messages do |data|
           message = MessageParser.parse(data)
           if message
             ClaudeAgentSDK.notify_observers(resolved_observers, :on_message, message)
-            block.call(message)
+            FiberBoundary.invoke { block.call(message) }
           end
         end
       ensure
@@ -406,7 +412,7 @@ module ClaudeAgentSDK
         message = MessageParser.parse(data)
         if message
           ClaudeAgentSDK.notify_observers(@resolved_observers, :on_message, message)
-          block.call(message)
+          FiberBoundary.invoke { block.call(message) }
         end
       end
     end

--- a/lib/claude_agent_sdk/fiber_boundary.rb
+++ b/lib/claude_agent_sdk/fiber_boundary.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module ClaudeAgentSDK
+  # Internal. Consumers of the SDK should never need this directly.
+  #
+  # The SDK depends on `async`, which installs a Fiber scheduler whenever an
+  # `Async { }` block is active. That scheduler multiplexes fibers onto a
+  # single OS thread and intercepts IO so blocking calls yield to siblings.
+  #
+  # Most mature Ruby libraries are thread-safe but not fiber-safe: they key
+  # state (checked-out DB connections, per-thread caches, request stores)
+  # on `Thread.current`. When the scheduler interleaves two fibers on one
+  # thread, those fibers share one state slot — and interleaved IO on a
+  # shared connection silently corrupts wire protocols. This bites every
+  # DB driver keyed by thread (pg, mysql2, sqlite3), ActiveRecord's
+  # connection pool, and any HTTP/cache client pooled per-thread.
+  #
+  # The SDK invokes user-supplied callbacks (tool handlers, hooks,
+  # permission callbacks, message blocks, observer methods) from inside
+  # its reactor. `FiberBoundary.invoke` hops those calls to a plain
+  # Ruby thread so user code runs on a fiber-scheduler-free thread and
+  # inherits the same thread-keyed state assumptions the rest of the
+  # user's app makes.
+  #
+  # No-op when no scheduler is active, so it's cheap to use unconditionally.
+  module FiberBoundary
+    module_function
+
+    # Run the given block on a plain thread when a Fiber scheduler is active.
+    # Returns the block's value. Exceptions propagate to the caller.
+    def invoke(&block)
+      return block.call unless Fiber.scheduler
+
+      thread = Thread.new(&block)
+      thread.report_on_exception = false
+      thread.value
+    end
+  end
+end

--- a/lib/claude_agent_sdk/query.rb
+++ b/lib/claude_agent_sdk/query.rb
@@ -300,11 +300,11 @@ module ClaudeAgentSDK
         agent_id: request_data[:agent_id]
       )
 
-      response = @can_use_tool.call(
-        request_data[:tool_name],
-        request_data[:input],
-        context
-      )
+      # User-supplied permission callback runs on a plain thread, not the
+      # Async reactor, so AR/PG calls inside it aren't intercepted.
+      response = FiberBoundary.invoke do
+        @can_use_tool.call(request_data[:tool_name], request_data[:input], context)
+      end
 
       # Convert PermissionResult to expected format
       case response
@@ -338,19 +338,21 @@ module ClaudeAgentSDK
       # Create typed HookContext
       context = HookContext.new(signal: nil)
 
-      hook_output = callback.call(
-        hook_input,
-        request_data[:tool_use_id],
-        context
-      ) unless @hook_callback_timeouts[callback_id]
+      # Hop off the Fiber scheduler before invoking user hook code. The
+      # Async-side timeout still wraps the hop; if it fires, .value returns
+      # early with an exception and the worker thread is left to finish on
+      # its own (matches prior best-effort cancellation semantics).
+      unless @hook_callback_timeouts[callback_id]
+        hook_output = FiberBoundary.invoke do
+          callback.call(hook_input, request_data[:tool_use_id], context)
+        end
+      end
 
       if (timeout = @hook_callback_timeouts[callback_id])
         hook_output = Async::Task.current.with_timeout(timeout) do
-          callback.call(
-            hook_input,
-            request_data[:tool_use_id],
-            context
-          )
+          FiberBoundary.invoke do
+            callback.call(hook_input, request_data[:tool_use_id], context)
+          end
         end
       end
 

--- a/lib/claude_agent_sdk/sdk_mcp_server.rb
+++ b/lib/claude_agent_sdk/sdk_mcp_server.rb
@@ -79,8 +79,9 @@ module ClaudeAgentSDK
       tool = @tools.find { |t| t.name == name }
       raise "Tool '#{name}' not found" unless tool
 
-      # Call the tool's handler
-      result = tool.handler.call(arguments)
+      # Call the tool's handler on a plain thread so the async gem's
+      # Fiber scheduler is not visible to user code (which may hit AR/PG).
+      result = FiberBoundary.invoke { tool.handler.call(arguments) }
 
       # Ensure result has the expected format
       unless result.is_a?(Hash) && result[:content]
@@ -180,8 +181,9 @@ module ClaudeAgentSDK
             end
 
             def call(server_context: nil, **args)
-              # Filter out server_context and pass remaining args to handler
-              result = @tool_def.handler.call(args)
+              # Filter out server_context and pass remaining args to handler.
+              # Hop to a plain thread so user handlers don't see the Fiber scheduler.
+              result = FiberBoundary.invoke { @tool_def.handler.call(args) }
 
               content = ClaudeAgentSDK.flexible_fetch(result, 'content', 'content')
               unless result.is_a?(Hash) && content

--- a/spec/unit/fiber_boundary_spec.rb
+++ b/spec/unit/fiber_boundary_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# The SDK depends on `async`, which installs a Fiber scheduler. If that
+# scheduler is visible to user-supplied callbacks, any IO those callbacks
+# perform (notably PostgreSQL via ActiveRecord) is intercepted by the
+# scheduler and can corrupt results. The SDK's job is to keep the scheduler
+# contained inside the SDK itself — user callbacks always see a plain
+# thread with `Fiber.scheduler == nil`.
+RSpec.describe 'Fiber scheduler boundary' do
+  def stub_query_handler_yielding(*messages)
+    handler = instance_double(
+      ClaudeAgentSDK::Query,
+      start: true,
+      initialize_protocol: nil,
+      wait_for_result_and_end_input: nil,
+      close: nil
+    )
+    allow(handler).to receive(:receive_messages) do |&block|
+      messages.each { |m| block.call(m) }
+    end
+    allow(ClaudeAgentSDK::Query).to receive(:new).and_return(handler)
+    handler
+  end
+
+  def stub_transport
+    transport = instance_double(
+      ClaudeAgentSDK::SubprocessCLITransport,
+      connect: true, close: nil, end_input: nil
+    )
+    allow(transport).to receive(:write)
+    allow(transport).to receive(:read_messages)
+    allow(ClaudeAgentSDK::SubprocessCLITransport).to receive(:new).and_return(transport)
+    transport
+  end
+
+  describe 'ClaudeAgentSDK.query { |message| ... }' do
+    it 'invokes the user block without a Fiber scheduler' do
+      stub_transport
+      stub_query_handler_yielding(
+        { type: 'assistant', message: { role: 'assistant', model: 'claude', content: [{ type: 'text', text: 'hi' }] } }
+      )
+
+      captured_scheduler = :unset
+      ClaudeAgentSDK.query(prompt: 'hi') do |_message|
+        captured_scheduler = Fiber.scheduler
+      end
+
+      expect(captured_scheduler).to be_nil
+    end
+
+    it 're-raises errors from the worker on the caller thread' do
+      stub_transport
+      handler = stub_query_handler_yielding
+      allow(handler).to receive(:receive_messages).and_raise(RuntimeError, 'worker boom')
+
+      expect { ClaudeAgentSDK.query(prompt: 'hi') { |_m| next } }.to raise_error(RuntimeError, 'worker boom')
+    end
+  end
+
+  describe 'ClaudeAgentSDK::Client#receive_messages { |message| ... }' do
+    it 'invokes the user block without a Fiber scheduler' do
+      stub_transport
+      stub_query_handler_yielding(
+        { type: 'assistant', message: { role: 'assistant', model: 'claude', content: [{ type: 'text', text: 'hi' }] } },
+        { type: 'result', subtype: 'success', duration_ms: 1, duration_api_ms: 1, is_error: false, num_turns: 1,
+          session_id: 's', total_cost_usd: 0 }
+      )
+
+      client = ClaudeAgentSDK::Client.new
+      client.connect
+
+      captured_scheduler = :unset
+      client.receive_response { |_msg| captured_scheduler = Fiber.scheduler }
+
+      expect(captured_scheduler).to be_nil
+    ensure
+      client&.disconnect
+    end
+  end
+
+  describe 'SDK MCP tool handler' do
+    it 'is invoked without a Fiber scheduler when called from inside an Async reactor' do
+      captured = :unset
+      tool = ClaudeAgentSDK.create_tool('probe', 'Probe', {}) do |_args|
+        captured = Fiber.scheduler
+        { content: [{ type: 'text', text: 'ok' }] }
+      end
+      server = ClaudeAgentSDK::SdkMcpServer.new(name: 'probe_server', tools: [tool])
+
+      Async { server.call_tool('probe', {}) }.wait
+
+      expect(captured).to be_nil
+    end
+  end
+
+  describe 'Hook callback' do
+    it 'is invoked without a Fiber scheduler' do
+      captured = :unset
+      hook_fn = lambda do |_input, _tool_use_id, _context|
+        captured = Fiber.scheduler
+        {}
+      end
+      hooks = { 'PreToolUse' => [{ matcher: 'Bash', hooks: [hook_fn] }] }
+      transport = instance_double(ClaudeAgentSDK::SubprocessCLITransport, write: nil, connect: nil, close: nil)
+
+      query = ClaudeAgentSDK::Query.new(
+        transport: transport,
+        is_streaming_mode: true,
+        hooks: hooks
+      )
+      # Register the callback by initializing once (registers id -> callback).
+      allow(query).to receive(:send_control_request).and_return({})
+      query.initialize_protocol
+
+      callback_id = query.instance_variable_get(:@hook_callbacks).keys.first
+      request_data = {
+        callback_id: callback_id,
+        input: { hook_event_name: 'PreToolUse' },
+        tool_use_id: 'toolu_1'
+      }
+
+      Async { query.send(:handle_hook_callback, request_data) }.wait
+
+      expect(captured).to be_nil
+    end
+  end
+end

--- a/spec/unit/query_spec.rb
+++ b/spec/unit/query_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe ClaudeAgentSDK::Query do
       query = described_class.new(transport: transport, is_streaming_mode: true)
 
       callback = lambda do |_input, _tool_use_id, _context|
-        Async::Task.current.sleep(0.05)
+        sleep(0.05)
         {}
       end
 


### PR DESCRIPTION
## What

Make `async`'s Fiber scheduler invisible to user-supplied callbacks — message blocks passed to `ClaudeAgentSDK.query` / `Client#receive_messages`, SDK MCP tool handlers, hooks, permission callbacks, and observer methods. Those callbacks now run on a plain Ruby `Thread` regardless of what the SDK is doing internally.

## How

A 5-line internal helper, `ClaudeAgentSDK::FiberBoundary.invoke`, hops to a plain thread when `Fiber.scheduler` is active and yields in place otherwise. It's applied at every user-callback invocation site inside the SDK:

- `ClaudeAgentSDK.query { |msg| … }` — message block
- `Client#receive_messages { |msg| … }` — message block
- `SdkMcpServer#call_tool` + the inner MCP tool class `#call` — tool handlers
- `Query#handle_hook_callback` — both timeout paths
- `Query#handle_permission_request` — `can_use_tool` callback
- `ClaudeAgentSDK.notify_observers` — every observer method

The SDK's internal reactor (transport, control protocol, receive loop, Query state) is unchanged — it remains fully `async`-native. Only the boundary between SDK code and user code moved.

5 new boundary specs (`spec/unit/fiber_boundary_spec.rb`); one existing spec updated (a hook callback was pinning fiber-coupled semantics via `Async::Task.current.sleep` — replaced with plain `sleep`, the with-timeout behavior still holds). Full suite: 547 / 0. Rubocop clean.

## Why

The SDK depends on `async`, whose Fiber scheduler multiplexes fibers onto one OS thread and intercepts IO. Most mature Ruby libraries — ActiveRecord and every thread-keyed DB driver (`pg`, `mysql2`, `sqlite3`), HTTP / cache pools, `RequestStore` and friends — key state on `Thread.current`. When the scheduler interleaves two fibers on the same thread, they share a single checked-out connection, interleaved IO corrupts wire protocols, and the user sees `MissingAttributeError`, `nil` `cmd_tuples`, missing columns, or whatever flavour of silent data corruption their library of choice produces.

Every Rails-based SDK consumer hits this. The workaround being carried downstream (`FiberSafeDb.run { }` wrappers at every call site) is boilerplate that shouldn't exist. Fixing it inside the SDK lets consumers delete those wrappers and write plain Ruby in their callbacks.

### Why here and not upstream in `async`

I looked. `socketry/async` has deliberately chosen not to offer a "scheduler-off" primitive — see [socketry/async#282](https://github.com/socketry/async/issues/282), [socketry/async#401](https://github.com/socketry/async/issues/401) (where the compatibility guide was removed outright), and [socketry/async#99](https://github.com/socketry/async/issues/99). The project's stance is that *libraries* should become fiber-safe, with `socketry/db`-style per-fiber pools as the intended answer. Rails has `isolation_level = :fiber` since 7.1 ([rails/rails#42271](https://github.com/rails/rails/issues/42271)) but thread-keyed DB drivers remain the weak link, so in practice AR is still the corruption point.

So neither side is moving: `async` won't add escape hatches; Rails/DB drivers won't go fiber-aware soon. The Claude Agent SDK sits between them, knows both sides, and is the pragmatic bridge. That's this PR.

### Why not a standalone gem

Investigated that too. No public gem does this today — each project (litestack's `Litescheduler`, Themis' `FiberSafeDb`) rolls the same ~5 lines inline. `async-safe` despite the name is a concurrency-bug *detector*; `async-pool` solves per-fiber resource pooling at a different layer. Adding a gem dependency for 5 lines would trade supply-chain surface for nothing. Keeping `FiberBoundary` as an internal implementation detail of the SDK — unexported, undocumented for consumers — keeps the public API minimal. Extraction to a standalone gem is trivially easy later if demand appears elsewhere in the `async`-based ecosystem.

## Trade-off worth flagging

Callbacks no longer run inside an `Async::Task`, so fiber-specific primitives aren't available to them — `Async::Task.current` will raise "No async task available" if code inside a callback tries to reach for it. A callback that wants cooperative concurrency can open its own `Async { }` block. In practice, callbacks do ordinary Ruby work and return a value; I audited a real SDK consumer (Themis, ~18 tool builders + 3 hook classes + all workflows) and found zero callbacks that use `Async::Task.current` or similar fiber primitives. Documenting this explicitly in the README so anyone relying on it sees the change before upgrading.

## Migration for consumers

Any project carrying a `FiberSafeDb.run { ... }` (or equivalent `Thread.new { AR op }.value` helper) can delete it and call the ORM directly inside callbacks. Top-level `Thread.new { Async { ... } }` wrappers used to isolate the whole SDK call are still fine; they no longer do anything useful, but they don't hurt either.