### PR TITLE
feat(messages): #text contract on AssistantMessage / UserMessage / SessionMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`#text` on every message type that carries content.** No more hand-rolling a `select { TextBlock }.map(&:text).join` in every consumer.
+  - `AssistantMessage#text` — joins text across `TextBlock`s in the content array.
+  - `UserMessage#text` — handles both String content (plain prompt) and Array-of-blocks content.
+  - `SessionMessage#text` — joins text across parsed content blocks from a historical transcript.
+  - `#to_s` on each message type is aliased to `#text`, so `puts message` and string interpolation just work.
+  - Non-text blocks (`ToolUseBlock`, `ThinkingBlock`, `ToolResultBlock`, `UnknownBlock`) intentionally do **not** answer `#text` — only `TextBlock` is textual. The message helpers use `Array#grep(TextBlock)` to select text blocks.
+- **`SessionMessage#content_blocks`** returns typed block objects (`TextBlock`, `ThinkingBlock`, `ToolUseBlock`, `ToolResultBlock`, `UnknownBlock`) instead of the raw hash blocks from the JSONL transcript. Unknown block types become `UnknownBlock` for forward compatibility with newer CLI versions.
+
+### Changed
+- Rails Integration / Quick Start / Observability / File Checkpointing README examples dropped the `content.select { is_a?(TextBlock) }.map(&:text).join` dance in favor of `message.text`.
+
 ## [0.15.0] - 2026-04-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -159,11 +159,7 @@ require 'claude_agent_sdk'
 
 # Simple query
 ClaudeAgentSDK.query(prompt: "Hello Claude") do |message|
-  if message.is_a?(ClaudeAgentSDK::AssistantMessage)
-    message.content.each do |block|
-      puts block.text if block.is_a?(ClaudeAgentSDK::TextBlock)
-    end
-  end
+  puts message.text if message.is_a?(ClaudeAgentSDK::AssistantMessage)
 end
 
 # With options
@@ -260,11 +256,10 @@ Async do
 
     # Receive the response
     client.receive_response do |msg|
-      if msg.is_a?(ClaudeAgentSDK::AssistantMessage)
-        msg.content.each do |block|
-          puts block.text if block.is_a?(ClaudeAgentSDK::TextBlock)
-        end
-      elsif msg.is_a?(ClaudeAgentSDK::ResultMessage)
+      case msg
+      when ClaudeAgentSDK::AssistantMessage
+        puts msg.text
+      when ClaudeAgentSDK::ResultMessage
         puts "Cost: $#{msg.total_cost_usd}" if msg.total_cost_usd
       end
     end
@@ -928,10 +923,7 @@ Async do
       # Capture UUID for rewind capability
       user_message_uuids << message.uuid if message.uuid
     when ClaudeAgentSDK::AssistantMessage
-      # Handle assistant responses
-      message.content.each do |block|
-        puts block.text if block.is_a?(ClaudeAgentSDK::TextBlock)
-      end
+      puts message.text
     when ClaudeAgentSDK::ResultMessage
       puts "Query completed (cost: $#{message.total_cost_usd})"
     end
@@ -1140,11 +1132,7 @@ options = ClaudeAgentSDK::ClaudeAgentOptions.new(
 )
 
 ClaudeAgentSDK.query(prompt: "List files in /tmp", options: options) do |msg|
-  if msg.is_a?(ClaudeAgentSDK::AssistantMessage)
-    msg.content.each do |block|
-      puts block.text if block.is_a?(ClaudeAgentSDK::TextBlock)
-    end
-  end
+  puts msg.text if msg.is_a?(ClaudeAgentSDK::AssistantMessage)
 end
 
 # For long-running apps, flush before exit:
@@ -1219,8 +1207,7 @@ class ChatAgentJob < ApplicationJob
         client.receive_response do |message|
           case message
           when ClaudeAgentSDK::AssistantMessage
-            text = extract_text(message)
-            ChatChannel.broadcast_to(chat_id, { type: 'chunk', content: text })
+            ChatChannel.broadcast_to(chat_id, { type: 'chunk', content: message.text })
 
           when ClaudeAgentSDK::ResultMessage
             ChatChannel.broadcast_to(chat_id, {
@@ -1234,15 +1221,6 @@ class ChatAgentJob < ApplicationJob
         client.disconnect
       end
     end.wait
-  end
-
-  private
-
-  def extract_text(message)
-    message.content
-      .select { |b| b.is_a?(ClaudeAgentSDK::TextBlock) }
-      .map(&:text)
-      .join("\n\n")
   end
 end
 ```

--- a/examples/rails_actioncable_example.rb
+++ b/examples/rails_actioncable_example.rb
@@ -65,31 +65,17 @@ module ChatChannel
   end
 end
 
-# Helper methods for extracting content from messages
+# Helper methods for extracting non-text content. Text extraction uses
+# the SDK's built-in `message.text`.
 module MessageExtractor
-  def self.extract_text(message)
-    return '' unless message.content.is_a?(Array)
-
-    message.content
-      .select { |block| block.is_a?(ClaudeAgentSDK::TextBlock) }
-      .map(&:text)
-      .join("\n\n")
-  end
-
   def self.extract_thinking(message)
-    return [] unless message.content.is_a?(Array)
-
-    message.content
-      .select { |block| block.is_a?(ClaudeAgentSDK::ThinkingBlock) }
-      .map(&:thinking)
+    Array(message.content).grep(ClaudeAgentSDK::ThinkingBlock).map(&:thinking)
   end
 
   def self.extract_tool_uses(message)
-    return [] unless message.content.is_a?(Array)
-
-    message.content
-      .select { |block| block.is_a?(ClaudeAgentSDK::ToolUseBlock) }
-      .map { |block| { name: block.name, input: block.input } }
+    Array(message.content).grep(ClaudeAgentSDK::ToolUseBlock).map do |block|
+      { name: block.name, input: block.input }
+    end
   end
 end
 
@@ -141,10 +127,9 @@ class ChatExecutor
           end
 
           # Broadcast text content
-          text = MessageExtractor.extract_text(message)
-          unless text.empty?
+          unless message.text.empty?
             ChatChannel.broadcast_chunk(@chat_id,
-              content: text,
+              content: message.text,
               message_id: @message_id
             )
           end

--- a/lib/claude_agent_sdk.rb
+++ b/lib/claude_agent_sdk.rb
@@ -67,11 +67,7 @@ module ClaudeAgentSDK
   #     permission_mode: 'acceptEdits'
   #   )
   #   ClaudeAgentSDK.query(prompt: "Create a hello.rb file", options: options) do |msg|
-  #     if msg.is_a?(ClaudeAgentSDK::AssistantMessage)
-  #       msg.content.each do |block|
-  #         puts block.text if block.is_a?(ClaudeAgentSDK::TextBlock)
-  #       end
-  #     end
+  #     puts msg.text if msg.is_a?(ClaudeAgentSDK::AssistantMessage)
   #   end
   #
   # @example Streaming input

--- a/lib/claude_agent_sdk/message_parser.rb
+++ b/lib/claude_agent_sdk/message_parser.rb
@@ -288,24 +288,32 @@ module ClaudeAgentSDK
       )
     end
 
+    # Accepts blocks with either symbol or string keys — live CLI messages
+    # arrive symbol-keyed (parsed via `symbolize_names: true`), session
+    # transcripts arrive string-keyed (parsed via `symbolize_names: false`).
+    # Uses a nil-aware fallback so `is_error: false` survives.
     def self.parse_content_block(block)
-      case block[:type]
+      get = lambda do |key|
+        v = block[key]
+        v.nil? ? block[key.to_s] : v
+      end
+      case get.call(:type)
       when 'text'
-        TextBlock.new(text: block[:text])
+        TextBlock.new(text: get.call(:text))
       when 'thinking'
-        ThinkingBlock.new(thinking: block[:thinking], signature: block[:signature])
+        ThinkingBlock.new(thinking: get.call(:thinking), signature: get.call(:signature))
       when 'tool_use'
-        ToolUseBlock.new(id: block[:id], name: block[:name], input: block[:input])
+        ToolUseBlock.new(id: get.call(:id), name: get.call(:name), input: get.call(:input))
       when 'tool_result'
         ToolResultBlock.new(
-          tool_use_id: block[:tool_use_id],
-          content: block[:content],
-          is_error: block[:is_error]
+          tool_use_id: get.call(:tool_use_id),
+          content: get.call(:content),
+          is_error: get.call(:is_error)
         )
       else
         # Forward-compatible: preserve unrecognized content block types (e.g., "document", "image")
         # so newer CLI versions don't crash older SDK versions.
-        UnknownBlock.new(type: block[:type], data: block)
+        UnknownBlock.new(type: get.call(:type), data: block)
       end
     end
   end

--- a/lib/claude_agent_sdk/sessions.rb
+++ b/lib/claude_agent_sdk/sessions.rb
@@ -38,6 +38,36 @@ module ClaudeAgentSDK
       @message = message
       @parent_tool_use_id = parent_tool_use_id
     end
+
+    # Concatenated text across every TextBlock in this message.
+    # Returns "" when the message has no text content (nil message,
+    # non-Hash message, empty content, or only non-text blocks).
+    def text
+      raw = @message.is_a?(Hash) ? (@message['content'] || @message[:content]) : nil
+      case raw
+      when String then raw
+      when Array  then content_blocks.grep(TextBlock).map(&:text).join("\n\n")
+      else ''
+      end
+    end
+
+    alias to_s text
+
+    # Typed content blocks for this message. Each entry is one of
+    # TextBlock, ThinkingBlock, ToolUseBlock, ToolResultBlock, or
+    # UnknownBlock (for forward-compatibility with newer CLI block types).
+    # Returns [] when the message has no array-of-blocks content (nil
+    # message, non-Hash message, String content, missing content).
+    def content_blocks
+      return [] unless @message.is_a?(Hash)
+
+      raw = @message['content'] || @message[:content]
+      return [] unless raw.is_a?(Array)
+
+      raw.filter_map do |block|
+        MessageParser.parse_content_block(block) if block.is_a?(Hash)
+      end
+    end
   end
 
   # Session browsing functions

--- a/lib/claude_agent_sdk/types.rb
+++ b/lib/claude_agent_sdk/types.rb
@@ -123,6 +123,19 @@ module ClaudeAgentSDK
       @parent_tool_use_id = parent_tool_use_id
       @tool_use_result = tool_use_result # Tool result data when message is a tool response
     end
+
+    # Concatenated text of this message. Handles both String content
+    # (plain-text user prompt) and Array-of-blocks content (typed content).
+    # Returns "" when there is no text.
+    def text
+      case @content
+      when String then @content
+      when Array then @content.grep(TextBlock).map(&:text).join("\n\n")
+      else ''
+      end
+    end
+
+    alias to_s text
   end
 
   # Assistant message with content blocks
@@ -142,6 +155,14 @@ module ClaudeAgentSDK
       @session_id = session_id # Session the message belongs to
       @uuid = uuid # Unique message UUID in the session transcript
     end
+
+    # Concatenated text across every TextBlock in this message's content.
+    # Returns "" when the message has no text (e.g., a pure tool_use turn).
+    def text
+      Array(@content).grep(TextBlock).map(&:text).join("\n\n")
+    end
+
+    alias to_s text
   end
 
   # System message with metadata

--- a/plugins/claude-agent-ruby/skills/claude-agent-ruby/references/message-handling.md
+++ b/plugins/claude-agent-ruby/skills/claude-agent-ruby/references/message-handling.md
@@ -41,15 +41,10 @@ end
 
 ## Extract assistant text
 
-```ruby
-def assistant_text(message)
-  return "" unless message.is_a?(ClaudeAgentSDK::AssistantMessage)
+`AssistantMessage`, `UserMessage`, and `SessionMessage` all answer `#text` (joined visible text, `""` when empty). `#to_s` is aliased to `#text`, so `puts message` works.
 
-  message.content
-    .select { |b| b.is_a?(ClaudeAgentSDK::TextBlock) }
-    .map(&:text)
-    .join("\n\n")
-end
+```ruby
+puts message.text if message.is_a?(ClaudeAgentSDK::AssistantMessage)
 ```
 
 ## Handle tool calls
@@ -58,7 +53,7 @@ end
 def tool_uses(message)
   return [] unless message.is_a?(ClaudeAgentSDK::AssistantMessage)
 
-  message.content.select { |b| b.is_a?(ClaudeAgentSDK::ToolUseBlock) }
+  Array(message.content).grep(ClaudeAgentSDK::ToolUseBlock)
 end
 ```
 
@@ -72,7 +67,7 @@ When using `Client#receive_response`, stop when you see `ClaudeAgentSDK::ResultM
 client.receive_response do |message|
   case message
   when ClaudeAgentSDK::AssistantMessage
-    puts assistant_text(message)
+    puts message.text
   when ClaudeAgentSDK::ResultMessage
     puts "Cost: $#{message.total_cost_usd}" if message.total_cost_usd
     puts "Session: #{message.session_id}"

--- a/plugins/claude-agent-ruby/skills/claude-agent-ruby/references/usage-map.md
+++ b/plugins/claude-agent-ruby/skills/claude-agent-ruby/references/usage-map.md
@@ -173,9 +173,7 @@ ClaudeAgentSDK.query(prompt: "Do something", options: options) do |msg|
   when ClaudeAgentSDK::InitMessage
     puts "Session started: #{msg.session_id} (#{msg.claude_code_version})"
   when ClaudeAgentSDK::AssistantMessage
-    msg.content.each do |block|
-      puts block.text if block.is_a?(ClaudeAgentSDK::TextBlock)
-    end
+    puts msg.text
   when ClaudeAgentSDK::CompactBoundaryMessage
     puts "Compacted: #{msg.compact_metadata&.pre_tokens} tokens (#{msg.compact_metadata&.trigger})"
   when ClaudeAgentSDK::StatusMessage

--- a/skills/references/message-handling.md
+++ b/skills/references/message-handling.md
@@ -41,15 +41,10 @@ end
 
 ## Extract assistant text
 
-```ruby
-def assistant_text(message)
-  return "" unless message.is_a?(ClaudeAgentSDK::AssistantMessage)
+`AssistantMessage`, `UserMessage`, and `SessionMessage` all answer `#text` (joined visible text, `""` when empty). `#to_s` is aliased to `#text`, so `puts message` works.
 
-  message.content
-    .select { |b| b.is_a?(ClaudeAgentSDK::TextBlock) }
-    .map(&:text)
-    .join("\n\n")
-end
+```ruby
+puts message.text if message.is_a?(ClaudeAgentSDK::AssistantMessage)
 ```
 
 ## Handle tool calls
@@ -58,7 +53,7 @@ end
 def tool_uses(message)
   return [] unless message.is_a?(ClaudeAgentSDK::AssistantMessage)
 
-  message.content.select { |b| b.is_a?(ClaudeAgentSDK::ToolUseBlock) }
+  Array(message.content).grep(ClaudeAgentSDK::ToolUseBlock)
 end
 ```
 
@@ -72,7 +67,7 @@ When using `Client#receive_response`, stop when you see `ClaudeAgentSDK::ResultM
 client.receive_response do |message|
   case message
   when ClaudeAgentSDK::AssistantMessage
-    puts assistant_text(message)
+    puts message.text
   when ClaudeAgentSDK::ResultMessage
     puts "Cost: $#{message.total_cost_usd}" if message.total_cost_usd
     puts "Session: #{message.session_id}"

--- a/skills/references/usage-map.md
+++ b/skills/references/usage-map.md
@@ -173,9 +173,7 @@ ClaudeAgentSDK.query(prompt: "Do something", options: options) do |msg|
   when ClaudeAgentSDK::InitMessage
     puts "Session started: #{msg.session_id} (#{msg.claude_code_version})"
   when ClaudeAgentSDK::AssistantMessage
-    msg.content.each do |block|
-      puts block.text if block.is_a?(ClaudeAgentSDK::TextBlock)
-    end
+    puts msg.text
   when ClaudeAgentSDK::CompactBoundaryMessage
     puts "Compacted: #{msg.compact_metadata&.pre_tokens} tokens (#{msg.compact_metadata&.trigger})"
   when ClaudeAgentSDK::StatusMessage

--- a/spec/unit/sessions_spec.rb
+++ b/spec/unit/sessions_spec.rb
@@ -687,6 +687,111 @@ RSpec.describe ClaudeAgentSDK::SessionMessage do
     expect(msg.message).to eq({ 'role' => 'user', 'content' => 'Hello' })
     expect(msg.parent_tool_use_id).to be_nil
   end
+
+  def build(message)
+    described_class.new(type: 'assistant', uuid: 'u', session_id: 's', message: message)
+  end
+
+  describe '#text' do
+    it 'returns "" when message is nil' do
+      expect(build(nil).text).to eq('')
+    end
+
+    it 'returns "" when message is not a Hash' do
+      expect(build('raw string').text).to eq('')
+    end
+
+    it 'returns the raw string when content is a String' do
+      expect(build({ 'role' => 'user', 'content' => 'Hello' }).text).to eq('Hello')
+    end
+
+    it 'concatenates text blocks in an Array content, skipping non-text blocks' do
+      msg = build(
+        'role' => 'assistant',
+        'content' => [
+          { 'type' => 'text', 'text' => 'First' },
+          { 'type' => 'tool_use', 'id' => 't1', 'name' => 'Read', 'input' => {} },
+          { 'type' => 'text', 'text' => 'Second' }
+        ]
+      )
+      expect(msg.text).to eq("First\n\nSecond")
+    end
+
+    it 'returns "" when content is an empty Array' do
+      expect(build('content' => []).text).to eq('')
+    end
+
+    it 'accepts symbol-keyed blocks as a fallback' do
+      msg = build(
+        content: [
+          { type: 'text', text: 'Sym' }
+        ]
+      )
+      expect(msg.text).to eq('Sym')
+    end
+
+    it 'aliases #to_s to #text' do
+      msg = build('content' => 'Hello')
+      expect(msg.to_s).to eq('Hello')
+      expect("got: #{msg}").to eq('got: Hello')
+    end
+  end
+
+  describe '#content_blocks' do
+    it 'returns [] when message is nil' do
+      expect(build(nil).content_blocks).to eq([])
+    end
+
+    it 'returns [] when message is not a Hash' do
+      expect(build(42).content_blocks).to eq([])
+    end
+
+    it 'returns [] when content is a String (no blocks existed in the transcript)' do
+      expect(build('content' => 'Hello').content_blocks).to eq([])
+    end
+
+    it 'parses typed blocks from an Array content' do
+      msg = build(
+        'content' => [
+          { 'type' => 'text', 'text' => 'Hi' },
+          { 'type' => 'tool_use', 'id' => 't1', 'name' => 'Read', 'input' => { 'path' => '/tmp/x' } },
+          { 'type' => 'thinking', 'thinking' => 'hmm', 'signature' => 'sig' },
+          { 'type' => 'tool_result', 'tool_use_id' => 't1', 'content' => 'ok', 'is_error' => false }
+        ]
+      )
+      blocks = msg.content_blocks
+      expect(blocks.map(&:class)).to eq(
+        [
+          ClaudeAgentSDK::TextBlock,
+          ClaudeAgentSDK::ToolUseBlock,
+          ClaudeAgentSDK::ThinkingBlock,
+          ClaudeAgentSDK::ToolResultBlock
+        ]
+      )
+      expect(blocks[0].text).to eq('Hi')
+      expect(blocks[1].id).to eq('t1')
+      expect(blocks[1].name).to eq('Read')
+      expect(blocks[1].input).to eq({ 'path' => '/tmp/x' })
+      expect(blocks[3].tool_use_id).to eq('t1')
+    end
+
+    it 'yields UnknownBlock for unrecognized block types' do
+      msg = build(
+        'content' => [
+          { 'type' => 'image', 'source' => { 'type' => 'base64', 'data' => '...' } }
+        ]
+      )
+      block = msg.content_blocks.first
+      expect(block).to be_a(ClaudeAgentSDK::UnknownBlock)
+      expect(block.type).to eq('image')
+    end
+
+    it 'skips non-Hash entries in a mixed Array' do
+      msg = build('content' => [{ 'type' => 'text', 'text' => 'ok' }, 'bare string', nil])
+      expect(msg.content_blocks.size).to eq(1)
+      expect(msg.content_blocks[0]).to be_a(ClaudeAgentSDK::TextBlock)
+    end
+  end
 end
 
 RSpec.describe 'ClaudeAgentSDK top-level session functions' do

--- a/spec/unit/types_spec.rb
+++ b/spec/unit/types_spec.rb
@@ -108,6 +108,78 @@ RSpec.describe ClaudeAgentSDK do
       end
     end
 
+    describe '#text uniform contract' do
+      let(:text_block) { ClaudeAgentSDK::TextBlock.new(text: 'Hi') }
+      let(:tool_use_block) { ClaudeAgentSDK::ToolUseBlock.new(id: 't1', name: 'Read', input: {}) }
+      let(:thinking_block) { ClaudeAgentSDK::ThinkingBlock.new(thinking: 'hmm', signature: 'sig') }
+      let(:tool_result_block) { ClaudeAgentSDK::ToolResultBlock.new(tool_use_id: 't1', content: 'ok') }
+      let(:unknown_block) { ClaudeAgentSDK::UnknownBlock.new(type: 'image', data: {}) }
+
+      describe 'content blocks' do
+        it 'TextBlock#text returns the text' do
+          expect(text_block.text).to eq('Hi')
+        end
+
+        it 'non-text blocks do not respond to #text' do
+          expect(tool_use_block).not_to respond_to(:text)
+          expect(thinking_block).not_to respond_to(:text)
+          expect(tool_result_block).not_to respond_to(:text)
+          expect(unknown_block).not_to respond_to(:text)
+        end
+      end
+
+      describe 'AssistantMessage#text' do
+        it 'concatenates text across typed blocks, skipping non-text' do
+          msg = ClaudeAgentSDK::AssistantMessage.new(
+            content: [
+              ClaudeAgentSDK::TextBlock.new(text: 'First'),
+              tool_use_block,
+              ClaudeAgentSDK::TextBlock.new(text: 'Second')
+            ],
+            model: 'claude-sonnet-4'
+          )
+          expect(msg.text).to eq("First\n\nSecond")
+        end
+
+        it 'returns "" when no text blocks are present' do
+          msg = ClaudeAgentSDK::AssistantMessage.new(content: [tool_use_block], model: 'claude-sonnet-4')
+          expect(msg.text).to eq('')
+        end
+
+        it 'aliases #to_s to #text' do
+          msg = ClaudeAgentSDK::AssistantMessage.new(content: [text_block], model: 'claude-sonnet-4')
+          expect(msg.to_s).to eq('Hi')
+          expect("got: #{msg}").to eq('got: Hi')
+        end
+      end
+
+      describe 'UserMessage#text' do
+        it 'returns the raw string when content is a String' do
+          expect(ClaudeAgentSDK::UserMessage.new(content: 'Hello').text).to eq('Hello')
+        end
+
+        it 'concatenates text across typed blocks' do
+          msg = ClaudeAgentSDK::UserMessage.new(
+            content: [
+              ClaudeAgentSDK::TextBlock.new(text: 'A'),
+              tool_use_block,
+              ClaudeAgentSDK::TextBlock.new(text: 'B')
+            ]
+          )
+          expect(msg.text).to eq("A\n\nB")
+        end
+
+        it 'returns "" when content is nil' do
+          expect(ClaudeAgentSDK::UserMessage.new(content: nil).text).to eq('')
+        end
+
+        it 'aliases #to_s to #text' do
+          msg = ClaudeAgentSDK::UserMessage.new(content: 'Hello')
+          expect(msg.to_s).to eq('Hello')
+        end
+      end
+    end
+
     describe ClaudeAgentSDK::SystemMessage do
       it 'stores system message data' do
         msg = described_class.new(subtype: 'info', data: { message: 'Test' })


### PR DESCRIPTION
## What

Make `#text` a first-class method on every message type that carries content. Add `SessionMessage#content_blocks` to expose typed blocks from session transcripts. Make `MessageParser.parse_content_block` accept either symbol-keyed or string-keyed blocks so the same parser works for live messages and JSONL transcripts.

## How

- `AssistantMessage#text` — joins text across `TextBlock`s in `@content`.
- `UserMessage#text` — handles String content (plain prompt) and Array-of-blocks content uniformly.
- `SessionMessage#text` — same shape, walks the (possibly nil / non-Hash / String / Array) raw transcript content.
- `#to_s` aliased to `#text` on all three, so `puts message` and string interpolation just work.
- `SessionMessage#content_blocks` parses string-keyed JSONL blocks into typed objects (`TextBlock`, `ThinkingBlock`, `ToolUseBlock`, `ToolResultBlock`, `UnknownBlock`). Returns `[]` when there's no array-of-blocks content — does *not* synthesize a phantom `TextBlock` for String content; that's `#text`'s job.
- `MessageParser.parse_content_block` is now key-tolerant via a small nil-aware fetch lambda, so it accepts symbol-keyed CLI messages and string-keyed JSONL transcripts identically. Drops the per-block `transform_keys(&:to_sym)` allocation in the session path.
- README quick-start, Observability, File Checkpointing, and ActionCable examples (4 sites) collapse to `puts message.text`. The standalone `examples/rails_actioncable_example.rb` drops `MessageExtractor.extract_text` and the two surviving extractors collapse to `grep`-based one-liners. YARD `@example` on `query` and the `skills/references/message-handling.md` + `usage-map.md` (plus plugin mirrors) updated to teach `message.text` instead of the hand-rolled helper.

564 specs / 0 failures, rubocop clean. No behavior change to live message parsing or session loading; purely additive on the public message types.

## Why

Every consumer of `query` / `Client#receive_messages` / `get_session_messages` reimplements the same dance:

```ruby
message.content
  .select { |b| b.is_a?(ClaudeAgentSDK::TextBlock) }
  .map(&:text)
  .join(\"\n\n\")
```

In four flavors of \`is_a?\` / \`case content\` / \`String|Array\` branching, scattered across the README, the actioncable example, the skill reference docs, downstream consumers (Themis carries an `extract_message_text` helper that's a copy of the README pattern), and even the SDK's own YARD examples. It's the kind of thing where reading the docs *teaches* you to write boilerplate.

`#text` is the name everyone guesses first. Once it's a first-class contract on every message type, the boilerplate disappears and the consumer code reads like the intent: \"give me the text.\"

### Design choices worth flagging

**Why not `#text` on every block too?** First version of this PR stubbed `ToolUseBlock#text`, `ThinkingBlock#text`, etc. to return `\"\"` so a uniform `content.map(&:text).join` would work. It's a polite fiction — tool_use isn't text, saying `tool_use.text == \"\"` is a lie. Removed: only `TextBlock#text` exists; the message implementations use `Array#grep(TextBlock)` to select text blocks. Honest modeling, fewer stubs, future-compatible (a new block type doesn't need to remember \"I'm not text\" — it just isn't).

**Why `SessionMessage#content_blocks` returns `[]` for String content** instead of wrapping it in a synthetic `TextBlock`: a caller counting blocks shouldn't see a block that didn't exist in the transcript. `#text` knows how to handle the String case directly; `#content_blocks` stays faithful to the transcript shape.

**Why make `parse_content_block` key-tolerant** rather than transforming keys at the SessionMessage call site: live messages and JSONL transcripts represent the same blocks with different key conventions; teaching the parser to accept both is one nil-aware lookup per field, removes the `transform_keys` allocation, and lets any future JSON-origin caller reuse the parser without ceremony. The only subtle bit is that the fallback uses `nil?` (not `||`) so `is_error: false` survives.

### Migration

Consumers carrying their own `extract_text(message)` / `assistant_text(message)` helper can delete it. `message.text` works on `AssistantMessage`, `UserMessage`, and `SessionMessage`. The Themis equivalent (`fetch_session_context` / `extract_message_text`) collapses to `session_messages.map(&:text)` after the SDK bumps.