### PR TITLE
Move OTel dev gems into optional Bundler group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,10 +10,18 @@ gem 'rspec', '~> 3.0'
 gem 'rubocop', '~> 1.0'
 gem 'yard', '~> 0.9'
 
-# Used by examples/ only; base64 was removed from Ruby 3.4's default gems.
-gem 'base64', '~> 0.2'
+# Optional group: only activated when explicitly requested (e.g. from an
+# example via Bundler.setup(:default, :instrumentation)). Kept out of the
+# default groups so `bundle exec rspec` doesn't put the real opentelemetry
+# gem on $LOAD_PATH — the instrumentation spec supplies its own mock and
+# breaks if the real gem is auto-loaded over it.
+group :instrumentation, optional: true do
+  # base64 was removed from Ruby 3.4's default gems; used by the OTel
+  # examples to encode Langfuse basic-auth credentials.
+  gem 'base64', '~> 0.2'
 
-# Used by examples/otel_langfuse_example.rb and instrumentation specs.
-# Kept out of the gemspec so end users only pay for OTel if they opt in.
-gem 'opentelemetry-sdk', '~> 1.4'
-gem 'opentelemetry-exporter-otlp', '~> 0.26'
+  # Used by examples/otel_langfuse_example.rb and examples/test_langfuse_otel.rb.
+  # Kept out of the gemspec so end users only pay for OTel if they opt in.
+  gem 'opentelemetry-exporter-otlp', '~> 0.26'
+  gem 'opentelemetry-sdk', '~> 1.4'
+end

--- a/examples/otel_langfuse_example.rb
+++ b/examples/otel_langfuse_example.rb
@@ -17,7 +17,9 @@
 # The same observer pattern works with any OTel backend (Jaeger, Datadog, etc.)
 # by configuring a different exporter.
 
-require 'bundler/setup'
+require 'bundler'
+Bundler.setup(:default, :instrumentation)
+
 require 'base64'
 require 'opentelemetry/sdk'
 require 'opentelemetry/exporter/otlp'

--- a/examples/test_langfuse_otel.rb
+++ b/examples/test_langfuse_otel.rb
@@ -14,6 +14,9 @@
 
 $LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
 
+require 'bundler'
+Bundler.setup(:default, :instrumentation)
+
 require 'base64'
 require 'opentelemetry/sdk'
 require 'opentelemetry/exporter/otlp'


### PR DESCRIPTION
## What

Moves `opentelemetry-sdk`, `opentelemetry-exporter-otlp`, and `base64` (added to the `Gemfile` in `855b424`) into a new `group :instrumentation, optional: true` so `bundle exec rspec` doesn't activate them by default. Updates the two OTel examples (`examples/otel_langfuse_example.rb`, `examples/test_langfuse_otel.rb`) to call `Bundler.setup(:default, :instrumentation)` before `require 'opentelemetry/sdk'`.

## Why

`855b424` landed the three gems in the default Gemfile groups. That broke `bundle exec rspec` immediately — 21 failures in `spec/unit/instrumentation/otel_spec.rb`.

Root cause: the spec mocks the `OpenTelemetry` namespace via a `$LOADED_FEATURES` short-circuit:

```ruby
$LOADED_FEATURES << 'opentelemetry' unless $LOADED_FEATURES.any? { |f| f.end_with?('/opentelemetry.rb') || f == 'opentelemetry' }
```

The trick only works when the real gem is absent from `$LOAD_PATH`. Ruby's `require 'opentelemetry'` normalizes to the resolved absolute path and checks `$LOADED_FEATURES` against that — the bare string `'opentelemetry'` doesn't match the resolved path. With the real gem on the load path, `require 'opentelemetry'` inside `OTelObserver#initialize` (`lib/claude_agent_sdk/instrumentation/otel.rb:44`) loads the real gem on top of the mocks. The real gem declares `class OpenTelemetry::Context` where the mock already has `module OpenTelemetry::Context`, producing:

```
TypeError: Context is not a class
previous definition of Context was here  # spec line 41
```

across every example that instantiates `OTelObserver`.

Wrapping the three gems in an optional Bundler group solves this without touching the spec's mock strategy. `bundle install` still installs them for dev convenience (running `examples/`), but `bundle exec rspec` no longer activates them, so the mock short-circuit remains effective.

## Test plan

- `bundle exec rake` locally: **547 examples, 0 failures, rubocop clean**
- CI will rerun across Ruby 3.2 / 3.3 / 3.4 with the same Gemfile

Post-merge this unblocks the `/release` cut for v0.15.1.