### PR TITLE
Fix LocalJumpError in Client#receive_response under Fiber scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.1] - 2026-04-21
+
+### Fixed
+- `Client#receive_response` no longer raises `LocalJumpError: break from proc-closure` when called inside `Async { }`. The 0.15.1 thread-hop severed `break`'s unwind target; replaced with a flag so the loop exits via the natural `end` marker after `ResultMessage`.
+
 ## [0.16.0] - 2026-04-22
 
 ### Added

--- a/lib/claude_agent_sdk.rb
+++ b/lib/claude_agent_sdk.rb
@@ -418,9 +418,15 @@ module ClaudeAgentSDK
     def receive_response(&block)
       return enum_for(:receive_response) unless block
 
+      # Flag-based rather than `break`: `receive_messages` hops this
+      # block onto a plain thread via `FiberBoundary.invoke`, which
+      # severs break's unwind target.
+      result_seen = false
       receive_messages do |message|
+        next if result_seen
+
         block.call(message)
-        break if message.is_a?(ResultMessage)
+        result_seen = true if message.is_a?(ResultMessage)
       end
     end
 

--- a/lib/claude_agent_sdk/version.rb
+++ b/lib/claude_agent_sdk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ClaudeAgentSDK
-  VERSION = '0.16.0'
+  VERSION = '0.16.1'
 end

--- a/spec/unit/fiber_boundary_spec.rb
+++ b/spec/unit/fiber_boundary_spec.rb
@@ -78,6 +78,33 @@ RSpec.describe 'Fiber scheduler boundary' do
     ensure
       client&.disconnect
     end
+
+    # Regression: `Client#receive_response` used to `break` on `ResultMessage`,
+    # but `receive_messages` hops to a plain thread via `FiberBoundary.invoke`
+    # when a Fiber scheduler is active. A thread hop severs the block from its
+    # defining method's call frame, so `break` raises `LocalJumpError` instead
+    # of unwinding. Must work inside an Async reactor.
+    it 'receive_response returns after ResultMessage without LocalJumpError inside Async' do
+      stub_transport
+      stub_query_handler_yielding(
+        { type: 'assistant', message: { role: 'assistant', model: 'claude', content: [{ type: 'text', text: 'hi' }] } },
+        { type: 'result', subtype: 'success', duration_ms: 1, duration_api_ms: 1, is_error: false, num_turns: 1,
+          session_id: 's', total_cost_usd: 0 }
+      )
+
+      received = []
+      Async do
+        client = ClaudeAgentSDK::Client.new
+        client.connect
+        begin
+          client.receive_response { |msg| received << msg.class }
+        ensure
+          client.disconnect
+        end
+      end.wait
+
+      expect(received).to eq([ClaudeAgentSDK::AssistantMessage, ClaudeAgentSDK::ResultMessage])
+    end
   end
 
   describe 'SDK MCP tool handler' do


### PR DESCRIPTION
## Summary
- `Client#receive_response` raises `LocalJumpError: break from proc-closure` on the first `ResultMessage` when called inside `Async { }`.
- Replaced the internal `break` with a flag-based early-return.
- Added a regression spec inside `Async { }`.
- Bumped to 0.16.1.

## Why
`receive_response` used `break if message.is_a?(ResultMessage)` inside a block it passed to `receive_messages`. Since 0.15.1, `receive_messages` invokes that block through `FiberBoundary.invoke { block.call(message) }`, which hops to a fresh `Thread` when a Fiber scheduler is active. `break` unwinds back to the method that passed the block along the call stack; once the block runs on a detached thread, the unwind target is gone and Ruby raises `LocalJumpError`.

Every one-shot `Async { client.receive_response { ... } }` caller crashed on the first `ResultMessage`. The existing spec missed this because it didn't wrap the call in `Async { }`, so no scheduler was active and `FiberBoundary` fell back to an inline `block.call` where break-across-method-boundary works.

## How
- `lib/claude_agent_sdk.rb` — `break` → `next if result_seen` flag. `QueryHandler#receive_messages` exits naturally when the CLI writes its `end` marker after `ResultMessage`, so the loop terminates on its own.
- `spec/unit/fiber_boundary_spec.rb` — regression spec that wraps the call in `Async { }` and asserts the user block receives both `AssistantMessage` and `ResultMessage`. Reproduces the original `LocalJumpError` on pre-fix code.
- `lib/claude_agent_sdk/version.rb` — 0.16.0 → 0.16.1.
- `CHANGELOG.md` — 0.16.1 Fixed entry.

## Test/Result
- `bundle exec rspec spec/unit/fiber_boundary_spec.rb` — 6 examples, 0 failures.
- `bundle exec rspec spec/unit/` — 570 examples, 0 failures.
- Verified the regression spec fails on pre-fix code with the exact production stack:
  ```
  LocalJumpError: break from proc-closure
    lib/claude_agent_sdk.rb:423:in 'block in Client#receive_response'
    lib/claude_agent_sdk.rb:411:in 'block (2 levels) in Client#receive_messages'
  ```