### PR TITLE
Extract CommandBuilder from SubprocessCLITransport

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,29 +11,6 @@ AllCops:
 Style/Documentation:
   Enabled: false
 
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-
-Style/StringLiteralsInInterpolation:
-  EnforcedStyle: double_quotes
-
-Layout/IndentationConsistency:
-  Enabled: true
-  EnforcedStyle: indented_internal_methods
-
-Layout/EmptyLinesAroundAccessModifier:
-  Enabled: true
-  EnforcedStyle: only_before
-
-Layout/LineLength:
-  Enabled: false
-
-Layout/TrailingEmptyLines:
-  Enabled: true
-
-Layout/TrailingWhitespace:
-  Enabled: true
-
 Metrics/MethodLength:
   Max: 30
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,29 @@ AllCops:
 Style/Documentation:
   Enabled: false
 
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
+
+Layout/IndentationConsistency:
+  Enabled: true
+  EnforcedStyle: indented_internal_methods
+
+Layout/EmptyLinesAroundAccessModifier:
+  Enabled: true
+  EnforcedStyle: only_before
+
+Layout/LineLength:
+  Enabled: false
+
+Layout/TrailingEmptyLines:
+  Enabled: true
+
+Layout/TrailingWhitespace:
+  Enabled: true
+
 Metrics/MethodLength:
   Max: 30
   Exclude:

--- a/lib/claude_agent_sdk/command_builder.rb
+++ b/lib/claude_agent_sdk/command_builder.rb
@@ -2,6 +2,7 @@
 
 require "json"
 require_relative "errors"
+require_relative "types"
 
 module ClaudeAgentSDK
   # Builds the CLI argv array from a ClaudeAgentOptions instance.
@@ -14,281 +15,277 @@ module ClaudeAgentSDK
     end
 
     def build
-      @cmd = [@cli_path, "--output-format", "stream-json", "--verbose"]
+      cmd = [@cli_path, "--output-format", "stream-json", "--verbose"]
 
-      append_system_prompt
-      append_tools
-      append_allowed_tools
-      append_disallowed_tools
-      append_max_turns
-      append_model
-      append_permission
-      append_session
-      append_settings
-      append_budget
-      append_thinking
-      append_effort
-      append_betas
-      append_append_allowed_tools
-      append_output_format
-      append_additional_dirs
-      append_mcp_servers
-      append_boolean_flags
-      append_plugins
-      append_setting_sources
-      append_extra_args
+      append_system_prompt(cmd)
+      append_tools(cmd)
+      append_allowed_tools(cmd)
+      append_disallowed_tools(cmd)
+      append_max_turns(cmd)
+      append_model(cmd)
+      append_permission(cmd)
+      append_session(cmd)
+      append_settings(cmd)
+      append_budget(cmd)
+      append_thinking(cmd)
+      append_effort(cmd)
+      append_betas(cmd)
+      append_append_allowed_tools(cmd)
+      append_output_format(cmd)
+      append_additional_dirs(cmd)
+      append_mcp_servers(cmd)
+      append_boolean_flags(cmd)
+      append_plugins(cmd)
+      append_setting_sources(cmd)
+      append_extra_args(cmd)
 
       # Always use streaming mode for bidirectional control protocol.
       # Prompts and agents are sent via stdin (initialize + user messages),
       # which avoids OS ARG_MAX limits for large prompts and agent configurations.
-      @cmd.push("--input-format", "stream-json")
+      cmd.push("--input-format", "stream-json")
 
-      @cmd
+      cmd
     end
 
     private
-      def append_system_prompt
-        case @options.system_prompt
-        when nil
-          # When nil, pass empty string to ensure predictable behavior without default Claude Code system prompt
-          @cmd.push("--system-prompt", "")
-        when String
-          @cmd.push("--system-prompt", @options.system_prompt)
-        when SystemPromptFile
-          @cmd.push("--system-prompt-file", @options.system_prompt.path)
-        when SystemPromptPreset
-          # Preset activates the default Claude Code system prompt by not passing --system-prompt ""
-          # Only --append-system-prompt is passed if append text is provided
-          @cmd.push("--append-system-prompt", @options.system_prompt.append) if @options.system_prompt.append
-        when Hash
-          append_hash_system_prompt(@options.system_prompt)
-        end
+
+    def append_system_prompt(cmd)
+      case @options.system_prompt
+      when nil
+        # When nil, pass empty string to ensure predictable behavior without default Claude Code system prompt
+        cmd.push("--system-prompt", "")
+      when String
+        cmd.push("--system-prompt", @options.system_prompt)
+      when SystemPromptFile
+        cmd.push("--system-prompt-file", @options.system_prompt.path)
+      when SystemPromptPreset
+        # Preset activates the default Claude Code system prompt by not passing --system-prompt ""
+        # Only --append-system-prompt is passed if append text is provided
+        cmd.push("--append-system-prompt", @options.system_prompt.append) if @options.system_prompt.append
+      when Hash
+        append_hash_system_prompt(cmd, @options.system_prompt)
       end
+    end
 
-      def append_hash_system_prompt(prompt_hash)
-        prompt_type = prompt_hash[:type] || prompt_hash["type"]
-        case prompt_type
-        when "file"
-          prompt_path = prompt_hash[:path] || prompt_hash["path"]
-          @cmd.push("--system-prompt-file", prompt_path) if prompt_path
-        when "preset"
-          append = prompt_hash[:append] || prompt_hash["append"]
-          # Preset activates the default Claude Code system prompt by not passing --system-prompt ""
-          @cmd.push("--append-system-prompt", append) if append
-        end
+    def append_hash_system_prompt(cmd, prompt_hash)
+      prompt_type = prompt_hash[:type] || prompt_hash["type"]
+      case prompt_type
+      when "file"
+        prompt_path = prompt_hash[:path] || prompt_hash["path"]
+        cmd.push("--system-prompt-file", prompt_path) if prompt_path
+      when "preset"
+        append = prompt_hash[:append] || prompt_hash["append"]
+        # Preset activates the default Claude Code system prompt by not passing --system-prompt ""
+        cmd.push("--append-system-prompt", append) if append
       end
+    end
 
-      def append_allowed_tools
-        @cmd.push("--allowedTools", @options.allowed_tools.join(",")) unless @options.allowed_tools.empty?
-      end
+    def append_allowed_tools(cmd)
+      cmd.push("--allowedTools", @options.allowed_tools.join(",")) unless @options.allowed_tools.empty?
+    end
 
-      def append_disallowed_tools
-        @cmd.push("--disallowedTools", @options.disallowed_tools.join(",")) unless @options.disallowed_tools.empty?
-      end
+    def append_disallowed_tools(cmd)
+      cmd.push("--disallowedTools", @options.disallowed_tools.join(",")) unless @options.disallowed_tools.empty?
+    end
 
-      def append_max_turns
-        @cmd.push("--max-turns", @options.max_turns.to_s) if @options.max_turns
-      end
+    def append_max_turns(cmd)
+      cmd.push("--max-turns", @options.max_turns.to_s) if @options.max_turns
+    end
 
-      def append_model
-        @cmd.push("--model", @options.model) if @options.model
-        @cmd.push("--fallback-model", @options.fallback_model) if @options.fallback_model
-      end
+    def append_model(cmd)
+      cmd.push("--model", @options.model) if @options.model
+      cmd.push("--fallback-model", @options.fallback_model) if @options.fallback_model
+    end
 
-      def append_permission
-        if @options.permission_prompt_tool_name
-          @cmd.push("--permission-prompt-tool", @options.permission_prompt_tool_name)
-        end
-        @cmd.push("--permission-mode", @options.permission_mode) if @options.permission_mode
-      end
+    def append_permission(cmd)
+      cmd.push("--permission-prompt-tool", @options.permission_prompt_tool_name) if @options.permission_prompt_tool_name
+      cmd.push("--permission-mode", @options.permission_mode) if @options.permission_mode
+    end
 
-      def append_session
-        @cmd.push("--continue") if @options.continue_conversation
-        @cmd.push("--resume", @options.resume) if @options.resume
-        @cmd.push("--session-id", @options.session_id) if @options.session_id
-      end
+    def append_session(cmd)
+      cmd.push("--continue") if @options.continue_conversation
+      cmd.push("--resume", @options.resume) if @options.resume
+      cmd.push("--session-id", @options.session_id) if @options.session_id
+    end
 
-      def append_settings
-        return unless @options.settings || @options.sandbox
+    def append_settings(cmd)
+      return unless @options.settings || @options.sandbox
 
-        settings_hash = {}
-        settings_is_path = false
+      settings_hash = {}
+      settings_is_path = false
 
-        if @options.settings
-          if @options.settings.is_a?(String)
-            begin
-              settings_hash = JSON.parse(@options.settings)
-            rescue JSON::ParserError
-              if @options.sandbox
-                settings_hash = load_settings_file(@options.settings)
-              else
-                settings_is_path = true
-                @cmd.push("--settings", @options.settings)
-              end
+      if @options.settings
+        if @options.settings.is_a?(String)
+          begin
+            settings_hash = JSON.parse(@options.settings)
+          rescue JSON::ParserError
+            if @options.sandbox
+              settings_hash = load_settings_file(@options.settings)
+            else
+              settings_is_path = true
+              cmd.push("--settings", @options.settings)
             end
-          elsif @options.settings.is_a?(Hash)
-            settings_hash = @options.settings.dup
           end
-        end
-
-        if !settings_is_path && @options.sandbox
-          sandbox_hash = @options.sandbox.is_a?(SandboxSettings) ? @options.sandbox.to_h : @options.sandbox
-          settings_hash[:sandbox] = sandbox_hash unless sandbox_hash.empty?
-        end
-
-        @cmd.push("--settings", JSON.generate(settings_hash)) if !settings_is_path && !settings_hash.empty?
-      end
-
-      def append_budget
-        @cmd.push("--max-budget-usd", @options.max_budget_usd.to_s) if @options.max_budget_usd
-
-        return unless @options.task_budget
-
-        total = if @options.task_budget.is_a?(TaskBudget)
-                  @options.task_budget.total
-                else
-                  @options.task_budget[:total] || @options.task_budget["total"]
-                end
-        @cmd.push("--task-budget", total.to_s) if total
-      end
-
-      # Thinking configuration takes precedence over deprecated max_thinking_tokens
-      def append_thinking
-        if @options.thinking
-          case @options.thinking
-          when ThinkingConfigAdaptive
-            @cmd.push("--thinking", "adaptive")
-          when ThinkingConfigEnabled
-            @cmd.push("--max-thinking-tokens", @options.thinking.budget_tokens.to_s)
-          when ThinkingConfigDisabled
-            @cmd.push("--thinking", "disabled")
-          end
-        elsif @options.max_thinking_tokens
-          @cmd.push("--max-thinking-tokens", @options.max_thinking_tokens.to_s)
+        elsif @options.settings.is_a?(Hash)
+          settings_hash = @options.settings.dup
         end
       end
 
-      # The set of supported levels is model-dependent; the CLI falls back to
-      # the highest supported level at or below the one requested
-      # (e.g. `xhigh` → `high` on Opus 4.6).
-      def append_effort
-        @cmd.push("--effort", @options.effort.to_s) if @options.effort
+      if !settings_is_path && @options.sandbox
+        sandbox_hash = @options.sandbox.is_a?(SandboxSettings) ? @options.sandbox.to_h : @options.sandbox
+        settings_hash[:sandbox] = sandbox_hash unless sandbox_hash.empty?
       end
 
-      def append_betas
-        return unless @options.betas && !@options.betas.empty?
+      cmd.push("--settings", JSON.generate(settings_hash)) if !settings_is_path && !settings_hash.empty?
+    end
 
-        @cmd.push("--betas", @options.betas.join(","))
-      end
+    def append_budget(cmd)
+      cmd.push("--max-budget-usd", @options.max_budget_usd.to_s) if @options.max_budget_usd
 
-      def append_tools
-        return if @options.tools.nil?
+      return unless @options.task_budget
 
-        if @options.tools.is_a?(Array)
-          tools_value = @options.tools.empty? ? "" : @options.tools.join(",")
-          @cmd.push("--tools", tools_value)
-        elsif @options.tools.is_a?(ToolsPreset)
-          @cmd.push("--tools", "default")
-        elsif @options.tools.is_a?(Hash)
-          if (@options.tools[:type] || @options.tools["type"]) == "preset"
-            @cmd.push("--tools", "default")
-          else
-            @cmd.push("--tools", JSON.generate(@options.tools))
-          end
+      total = if @options.task_budget.is_a?(TaskBudget)
+                @options.task_budget.total
+              else
+                @options.task_budget[:total] || @options.task_budget["total"]
+              end
+      cmd.push("--task-budget", total.to_s) if total
+    end
+
+    # Thinking configuration takes precedence over deprecated max_thinking_tokens
+    def append_thinking(cmd)
+      if @options.thinking
+        case @options.thinking
+        when ThinkingConfigAdaptive
+          cmd.push("--thinking", "adaptive")
+        when ThinkingConfigEnabled
+          cmd.push("--max-thinking-tokens", @options.thinking.budget_tokens.to_s)
+        when ThinkingConfigDisabled
+          cmd.push("--thinking", "disabled")
         end
+      elsif @options.max_thinking_tokens
+        cmd.push("--max-thinking-tokens", @options.max_thinking_tokens.to_s)
       end
+    end
 
-      def append_append_allowed_tools
-        return unless @options.append_allowed_tools && !@options.append_allowed_tools.empty?
+    # The set of supported levels is model-dependent; the CLI falls back to
+    # the highest supported level at or below the one requested
+    # (e.g. `xhigh` → `high` on Opus 4.6).
+    def append_effort(cmd)
+      cmd.push("--effort", @options.effort.to_s) if @options.effort
+    end
 
-        @cmd.push("--append-allowed-tools", @options.append_allowed_tools.join(","))
-      end
+    def append_betas(cmd)
+      return unless @options.betas && !@options.betas.empty?
 
-      def append_output_format
-        return unless @options.output_format
+      cmd.push("--betas", @options.betas.join(","))
+    end
 
-        schema = if @options.output_format.is_a?(Hash) && @options.output_format[:type] == "json_schema"
-                   @options.output_format[:schema]
-                 elsif @options.output_format.is_a?(Hash) && @options.output_format["type"] == "json_schema"
-                   @options.output_format["schema"]
-                 else
-                   @options.output_format
-                 end
-        schema_json = schema.is_a?(String) ? schema : JSON.generate(schema)
-        @cmd.push("--json-schema", schema_json)
-      end
+    def append_tools(cmd)
+      return if @options.tools.nil?
 
-      def append_additional_dirs
-        @options.add_dirs.each { |dir| @cmd.push("--add-dir", dir.to_s) }
-      end
-
-      def append_mcp_servers
-        return unless @options.mcp_servers && !@options.mcp_servers.empty?
-
-        if @options.mcp_servers.is_a?(Hash)
-          servers_for_cli = {}
-          @options.mcp_servers.each do |name, config|
-            servers_for_cli[name] = if config.is_a?(Hash) && config[:type] == "sdk"
-                                      config.reject { |k, _| k == :instance }
-                                    else
-                                      config
-                                    end
-          end
-          @cmd.push("--mcp-config", JSON.generate({ mcpServers: servers_for_cli })) unless servers_for_cli.empty?
+      case @options.tools
+      when Array
+        tools_value = @options.tools.empty? ? "" : @options.tools.join(",")
+        cmd.push("--tools", tools_value)
+      when ToolsPreset
+        cmd.push("--tools", "default")
+      when Hash
+        if (@options.tools[:type] || @options.tools["type"]) == "preset"
+          cmd.push("--tools", "default")
         else
-          @cmd.push("--mcp-config", @options.mcp_servers.to_s)
+          cmd.push("--tools", JSON.generate(@options.tools))
         end
       end
+    end
 
-      # Note: agents are sent via the initialize control request (not CLI args)
-      # to avoid OS ARG_MAX limits with large agent configurations.
-      def append_boolean_flags
-        @cmd.push("--include-partial-messages") if @options.include_partial_messages
-        @cmd.push("--fork-session") if @options.fork_session
-        @cmd.push("--bare") if @options.bare
+    def append_append_allowed_tools(cmd)
+      return unless @options.append_allowed_tools && !@options.append_allowed_tools.empty?
+
+      cmd.push("--append-allowed-tools", @options.append_allowed_tools.join(","))
+    end
+
+    def append_output_format(cmd)
+      return unless @options.output_format
+
+      schema = if @options.output_format.is_a?(Hash) && @options.output_format[:type] == "json_schema"
+                 @options.output_format[:schema]
+               elsif @options.output_format.is_a?(Hash) && @options.output_format["type"] == "json_schema"
+                 @options.output_format["schema"]
+               else
+                 @options.output_format
+               end
+      schema_json = schema.is_a?(String) ? schema : JSON.generate(schema)
+      cmd.push("--json-schema", schema_json)
+    end
+
+    def append_additional_dirs(cmd)
+      @options.add_dirs.each { |dir| cmd.push("--add-dir", dir.to_s) }
+    end
+
+    def append_mcp_servers(cmd)
+      return unless @options.mcp_servers && !@options.mcp_servers.empty?
+
+      if @options.mcp_servers.is_a?(Hash)
+        servers_for_cli = {}
+        @options.mcp_servers.each do |name, config|
+          servers_for_cli[name] = if config.is_a?(Hash) && config[:type] == "sdk"
+                                    config.except(:instance)
+                                  else
+                                    config
+                                  end
+        end
+        cmd.push("--mcp-config", JSON.generate({ mcpServers: servers_for_cli })) unless servers_for_cli.empty?
+      else
+        cmd.push("--mcp-config", @options.mcp_servers.to_s)
       end
+    end
 
-      def append_plugins
-        return unless @options.plugins && !@options.plugins.empty?
+    # NOTE: agents are sent via the initialize control request (not CLI args)
+    # to avoid OS ARG_MAX limits with large agent configurations.
+    def append_boolean_flags(cmd)
+      cmd.push("--include-partial-messages") if @options.include_partial_messages
+      cmd.push("--fork-session") if @options.fork_session
+      cmd.push("--bare") if @options.bare
+    end
 
-        @options.plugins.each do |plugin|
-          plugin_config = plugin.is_a?(SdkPluginConfig) ? plugin.to_h : plugin
-          plugin_type = plugin_config[:type] || plugin_config["type"]
-          plugin_path = plugin_config[:path] || plugin_config["path"]
+    def append_plugins(cmd)
+      return unless @options.plugins && !@options.plugins.empty?
 
-          unless %w[local plugin].include?(plugin_type)
-            raise ArgumentError, "Unsupported plugin type: #{plugin_type.inspect}"
-          end
-          next unless plugin_path
+      @options.plugins.each do |plugin|
+        plugin_config = plugin.is_a?(SdkPluginConfig) ? plugin.to_h : plugin
+        plugin_type = plugin_config[:type] || plugin_config["type"]
+        plugin_path = plugin_config[:path] || plugin_config["path"]
 
-          @cmd.push("--plugin-dir", plugin_path)
+        raise ArgumentError, "Unsupported plugin type: #{plugin_type.inspect}" unless %w[local plugin].include?(plugin_type)
+        next unless plugin_path
+
+        cmd.push("--plugin-dir", plugin_path)
+      end
+    end
+
+    def append_setting_sources(cmd)
+      return unless @options.setting_sources
+
+      cmd.push("--setting-sources", @options.setting_sources.join(","))
+    end
+
+    def append_extra_args(cmd)
+      @options.extra_args.each do |flag, value|
+        raise ArgumentError, "Invalid extra_args flag name: #{flag.inspect} (expected lowercase kebab-case)" unless EXTRA_ARG_FLAG_REGEXP.match?(flag)
+
+        if value.nil?
+          cmd.push("--#{flag}")
+        else
+          cmd.push("--#{flag}", value.to_s)
         end
       end
+    end
 
-      def append_setting_sources
-        return unless @options.setting_sources
+    def load_settings_file(path)
+      raise CLIConnectionError, "Settings file not found: #{path}" unless File.file?(path)
 
-        @cmd.push("--setting-sources", @options.setting_sources.join(","))
-      end
-
-      def append_extra_args
-        @options.extra_args.each do |flag, value|
-          unless EXTRA_ARG_FLAG_REGEXP.match?(flag)
-            raise ArgumentError, "Invalid extra_args flag name: #{flag.inspect} (expected lowercase kebab-case)"
-          end
-
-          if value.nil?
-            @cmd.push("--#{flag}")
-          else
-            @cmd.push("--#{flag}", value.to_s)
-          end
-        end
-      end
-
-      def load_settings_file(path)
-        raise CLIConnectionError, "Settings file not found: #{path}" unless File.file?(path)
-
-        JSON.parse(File.read(path))
-      end
+      JSON.parse(File.read(path))
+    end
   end
 end

--- a/lib/claude_agent_sdk/command_builder.rb
+++ b/lib/claude_agent_sdk/command_builder.rb
@@ -1,0 +1,294 @@
+# frozen_string_literal: true
+
+require "json"
+require_relative "errors"
+
+module ClaudeAgentSDK
+  # Builds the CLI argv array from a ClaudeAgentOptions instance.
+  class CommandBuilder
+    EXTRA_ARG_FLAG_REGEXP = /\A[a-z0-9][a-z0-9-]*\z/
+
+    def initialize(cli_path, options)
+      @cli_path = cli_path
+      @options = options
+    end
+
+    def build
+      @cmd = [@cli_path, "--output-format", "stream-json", "--verbose"]
+
+      append_system_prompt
+      append_tools
+      append_allowed_tools
+      append_disallowed_tools
+      append_max_turns
+      append_model
+      append_permission
+      append_session
+      append_settings
+      append_budget
+      append_thinking
+      append_effort
+      append_betas
+      append_append_allowed_tools
+      append_output_format
+      append_additional_dirs
+      append_mcp_servers
+      append_boolean_flags
+      append_plugins
+      append_setting_sources
+      append_extra_args
+
+      # Always use streaming mode for bidirectional control protocol.
+      # Prompts and agents are sent via stdin (initialize + user messages),
+      # which avoids OS ARG_MAX limits for large prompts and agent configurations.
+      @cmd.push("--input-format", "stream-json")
+
+      @cmd
+    end
+
+    private
+      def append_system_prompt
+        case @options.system_prompt
+        when nil
+          # When nil, pass empty string to ensure predictable behavior without default Claude Code system prompt
+          @cmd.push("--system-prompt", "")
+        when String
+          @cmd.push("--system-prompt", @options.system_prompt)
+        when SystemPromptFile
+          @cmd.push("--system-prompt-file", @options.system_prompt.path)
+        when SystemPromptPreset
+          # Preset activates the default Claude Code system prompt by not passing --system-prompt ""
+          # Only --append-system-prompt is passed if append text is provided
+          @cmd.push("--append-system-prompt", @options.system_prompt.append) if @options.system_prompt.append
+        when Hash
+          append_hash_system_prompt(@options.system_prompt)
+        end
+      end
+
+      def append_hash_system_prompt(prompt_hash)
+        prompt_type = prompt_hash[:type] || prompt_hash["type"]
+        case prompt_type
+        when "file"
+          prompt_path = prompt_hash[:path] || prompt_hash["path"]
+          @cmd.push("--system-prompt-file", prompt_path) if prompt_path
+        when "preset"
+          append = prompt_hash[:append] || prompt_hash["append"]
+          # Preset activates the default Claude Code system prompt by not passing --system-prompt ""
+          @cmd.push("--append-system-prompt", append) if append
+        end
+      end
+
+      def append_allowed_tools
+        @cmd.push("--allowedTools", @options.allowed_tools.join(",")) unless @options.allowed_tools.empty?
+      end
+
+      def append_disallowed_tools
+        @cmd.push("--disallowedTools", @options.disallowed_tools.join(",")) unless @options.disallowed_tools.empty?
+      end
+
+      def append_max_turns
+        @cmd.push("--max-turns", @options.max_turns.to_s) if @options.max_turns
+      end
+
+      def append_model
+        @cmd.push("--model", @options.model) if @options.model
+        @cmd.push("--fallback-model", @options.fallback_model) if @options.fallback_model
+      end
+
+      def append_permission
+        if @options.permission_prompt_tool_name
+          @cmd.push("--permission-prompt-tool", @options.permission_prompt_tool_name)
+        end
+        @cmd.push("--permission-mode", @options.permission_mode) if @options.permission_mode
+      end
+
+      def append_session
+        @cmd.push("--continue") if @options.continue_conversation
+        @cmd.push("--resume", @options.resume) if @options.resume
+        @cmd.push("--session-id", @options.session_id) if @options.session_id
+      end
+
+      def append_settings
+        return unless @options.settings || @options.sandbox
+
+        settings_hash = {}
+        settings_is_path = false
+
+        if @options.settings
+          if @options.settings.is_a?(String)
+            begin
+              settings_hash = JSON.parse(@options.settings)
+            rescue JSON::ParserError
+              if @options.sandbox
+                settings_hash = load_settings_file(@options.settings)
+              else
+                settings_is_path = true
+                @cmd.push("--settings", @options.settings)
+              end
+            end
+          elsif @options.settings.is_a?(Hash)
+            settings_hash = @options.settings.dup
+          end
+        end
+
+        if !settings_is_path && @options.sandbox
+          sandbox_hash = @options.sandbox.is_a?(SandboxSettings) ? @options.sandbox.to_h : @options.sandbox
+          settings_hash[:sandbox] = sandbox_hash unless sandbox_hash.empty?
+        end
+
+        @cmd.push("--settings", JSON.generate(settings_hash)) if !settings_is_path && !settings_hash.empty?
+      end
+
+      def append_budget
+        @cmd.push("--max-budget-usd", @options.max_budget_usd.to_s) if @options.max_budget_usd
+
+        return unless @options.task_budget
+
+        total = if @options.task_budget.is_a?(TaskBudget)
+                  @options.task_budget.total
+                else
+                  @options.task_budget[:total] || @options.task_budget["total"]
+                end
+        @cmd.push("--task-budget", total.to_s) if total
+      end
+
+      # Thinking configuration takes precedence over deprecated max_thinking_tokens
+      def append_thinking
+        if @options.thinking
+          case @options.thinking
+          when ThinkingConfigAdaptive
+            @cmd.push("--thinking", "adaptive")
+          when ThinkingConfigEnabled
+            @cmd.push("--max-thinking-tokens", @options.thinking.budget_tokens.to_s)
+          when ThinkingConfigDisabled
+            @cmd.push("--thinking", "disabled")
+          end
+        elsif @options.max_thinking_tokens
+          @cmd.push("--max-thinking-tokens", @options.max_thinking_tokens.to_s)
+        end
+      end
+
+      # The set of supported levels is model-dependent; the CLI falls back to
+      # the highest supported level at or below the one requested
+      # (e.g. `xhigh` → `high` on Opus 4.6).
+      def append_effort
+        @cmd.push("--effort", @options.effort.to_s) if @options.effort
+      end
+
+      def append_betas
+        return unless @options.betas && !@options.betas.empty?
+
+        @cmd.push("--betas", @options.betas.join(","))
+      end
+
+      def append_tools
+        return if @options.tools.nil?
+
+        if @options.tools.is_a?(Array)
+          tools_value = @options.tools.empty? ? "" : @options.tools.join(",")
+          @cmd.push("--tools", tools_value)
+        elsif @options.tools.is_a?(ToolsPreset)
+          @cmd.push("--tools", "default")
+        elsif @options.tools.is_a?(Hash)
+          if (@options.tools[:type] || @options.tools["type"]) == "preset"
+            @cmd.push("--tools", "default")
+          else
+            @cmd.push("--tools", JSON.generate(@options.tools))
+          end
+        end
+      end
+
+      def append_append_allowed_tools
+        return unless @options.append_allowed_tools && !@options.append_allowed_tools.empty?
+
+        @cmd.push("--append-allowed-tools", @options.append_allowed_tools.join(","))
+      end
+
+      def append_output_format
+        return unless @options.output_format
+
+        schema = if @options.output_format.is_a?(Hash) && @options.output_format[:type] == "json_schema"
+                   @options.output_format[:schema]
+                 elsif @options.output_format.is_a?(Hash) && @options.output_format["type"] == "json_schema"
+                   @options.output_format["schema"]
+                 else
+                   @options.output_format
+                 end
+        schema_json = schema.is_a?(String) ? schema : JSON.generate(schema)
+        @cmd.push("--json-schema", schema_json)
+      end
+
+      def append_additional_dirs
+        @options.add_dirs.each { |dir| @cmd.push("--add-dir", dir.to_s) }
+      end
+
+      def append_mcp_servers
+        return unless @options.mcp_servers && !@options.mcp_servers.empty?
+
+        if @options.mcp_servers.is_a?(Hash)
+          servers_for_cli = {}
+          @options.mcp_servers.each do |name, config|
+            servers_for_cli[name] = if config.is_a?(Hash) && config[:type] == "sdk"
+                                      config.reject { |k, _| k == :instance }
+                                    else
+                                      config
+                                    end
+          end
+          @cmd.push("--mcp-config", JSON.generate({ mcpServers: servers_for_cli })) unless servers_for_cli.empty?
+        else
+          @cmd.push("--mcp-config", @options.mcp_servers.to_s)
+        end
+      end
+
+      # Note: agents are sent via the initialize control request (not CLI args)
+      # to avoid OS ARG_MAX limits with large agent configurations.
+      def append_boolean_flags
+        @cmd.push("--include-partial-messages") if @options.include_partial_messages
+        @cmd.push("--fork-session") if @options.fork_session
+        @cmd.push("--bare") if @options.bare
+      end
+
+      def append_plugins
+        return unless @options.plugins && !@options.plugins.empty?
+
+        @options.plugins.each do |plugin|
+          plugin_config = plugin.is_a?(SdkPluginConfig) ? plugin.to_h : plugin
+          plugin_type = plugin_config[:type] || plugin_config["type"]
+          plugin_path = plugin_config[:path] || plugin_config["path"]
+
+          unless %w[local plugin].include?(plugin_type)
+            raise ArgumentError, "Unsupported plugin type: #{plugin_type.inspect}"
+          end
+          next unless plugin_path
+
+          @cmd.push("--plugin-dir", plugin_path)
+        end
+      end
+
+      def append_setting_sources
+        return unless @options.setting_sources
+
+        @cmd.push("--setting-sources", @options.setting_sources.join(","))
+      end
+
+      def append_extra_args
+        @options.extra_args.each do |flag, value|
+          unless EXTRA_ARG_FLAG_REGEXP.match?(flag)
+            raise ArgumentError, "Invalid extra_args flag name: #{flag.inspect} (expected lowercase kebab-case)"
+          end
+
+          if value.nil?
+            @cmd.push("--#{flag}")
+          else
+            @cmd.push("--#{flag}", value.to_s)
+          end
+        end
+      end
+
+      def load_settings_file(path)
+        raise CLIConnectionError, "Settings file not found: #{path}" unless File.file?(path)
+
+        JSON.parse(File.read(path))
+      end
+  end
+end

--- a/lib/claude_agent_sdk/subprocess_cli_transport.rb
+++ b/lib/claude_agent_sdk/subprocess_cli_transport.rb
@@ -6,13 +6,13 @@ require 'timeout'
 require_relative 'transport'
 require_relative 'errors'
 require_relative 'version'
+require_relative 'command_builder'
 
 module ClaudeAgentSDK
   # Subprocess transport using Claude Code CLI
   class SubprocessCLITransport < Transport
     DEFAULT_MAX_BUFFER_SIZE = 1024 * 1024 # 1MB buffer limit
     MINIMUM_CLAUDE_CODE_VERSION = '2.0.0'
-    EXTRA_ARG_FLAG_RE = /\A[a-z0-9][a-z0-9-]*\z/
 
     def initialize(options_or_prompt = nil, options = nil)
       # Support both new single-arg form and legacy two-arg form
@@ -67,126 +67,7 @@ module ClaudeAgentSDK
     end
 
     def build_command
-      cmd = [@cli_path, '--output-format', 'stream-json', '--verbose']
-
-      # System prompt handling
-      # When nil, pass empty string to ensure predictable behavior without default Claude Code system prompt
-      if @options.system_prompt.nil?
-        cmd.concat(['--system-prompt', ''])
-      elsif @options.system_prompt.is_a?(String)
-        cmd.concat(['--system-prompt', @options.system_prompt])
-      elsif @options.system_prompt.is_a?(SystemPromptFile)
-        cmd.concat(['--system-prompt-file', @options.system_prompt.path])
-      elsif @options.system_prompt.is_a?(SystemPromptPreset)
-        # Preset activates the default Claude Code system prompt by not passing --system-prompt ""
-        # Only --append-system-prompt is passed if append text is provided
-        cmd.concat(['--append-system-prompt', @options.system_prompt.append]) if @options.system_prompt.append
-      elsif @options.system_prompt.is_a?(Hash)
-        prompt_type = @options.system_prompt[:type] || @options.system_prompt['type']
-        if prompt_type == 'file'
-          prompt_path = @options.system_prompt[:path] || @options.system_prompt['path']
-          cmd.concat(['--system-prompt-file', prompt_path]) if prompt_path
-        elsif prompt_type == 'preset'
-          append = @options.system_prompt[:append] || @options.system_prompt['append']
-          # Preset activates the default Claude Code system prompt by not passing --system-prompt ""
-          cmd.concat(['--append-system-prompt', append]) if append
-        end
-      end
-
-      cmd.concat(['--allowedTools', @options.allowed_tools.join(',')]) unless @options.allowed_tools.empty?
-      cmd.concat(['--max-turns', @options.max_turns.to_s]) if @options.max_turns
-      cmd.concat(['--disallowedTools', @options.disallowed_tools.join(',')]) unless @options.disallowed_tools.empty?
-      cmd.concat(['--model', @options.model]) if @options.model
-      cmd.concat(['--fallback-model', @options.fallback_model]) if @options.fallback_model
-      cmd.concat(['--permission-prompt-tool', @options.permission_prompt_tool_name]) if @options.permission_prompt_tool_name
-      cmd.concat(['--permission-mode', @options.permission_mode]) if @options.permission_mode
-      cmd << '--continue' if @options.continue_conversation
-      cmd.concat(['--resume', @options.resume]) if @options.resume
-      cmd.concat(['--session-id', @options.session_id]) if @options.session_id
-
-      # Settings handling with sandbox merge
-      build_settings_args(cmd)
-
-      # Budget limit option
-      cmd.concat(['--max-budget-usd', @options.max_budget_usd.to_s]) if @options.max_budget_usd
-
-      # Task budget (API-side token budget)
-      if @options.task_budget
-        total = if @options.task_budget.is_a?(TaskBudget)
-                  @options.task_budget.total
-                else
-                  @options.task_budget[:total] || @options.task_budget['total']
-                end
-        cmd.concat(['--task-budget', total.to_s]) if total
-      end
-
-      # Thinking configuration (takes precedence over deprecated max_thinking_tokens)
-      build_thinking_args(cmd)
-
-      # Effort level — see ClaudeAgentSDK::EFFORT_LEVELS. The set of supported
-      # levels is model-dependent; the CLI falls back to the highest supported
-      # level at or below the one requested (e.g. `xhigh` → `high` on Opus 4.6).
-      cmd.concat(['--effort', @options.effort.to_s]) if @options.effort
-
-      # Betas option for enabling experimental features
-      if @options.betas && !@options.betas.empty?
-        cmd.concat(['--betas', @options.betas.join(',')])
-      end
-
-      # Tools option for base tools selection
-      build_tools_args(cmd)
-
-      # Append allowed tools option
-      if @options.append_allowed_tools && !@options.append_allowed_tools.empty?
-        cmd.concat(['--append-allowed-tools', @options.append_allowed_tools.join(',')])
-      end
-
-      # JSON schema for structured output
-      build_output_format_args(cmd)
-
-      # Add directories
-      @options.add_dirs.each do |dir|
-        cmd.concat(['--add-dir', dir.to_s])
-      end
-
-      # MCP servers
-      build_mcp_servers_args(cmd)
-
-      cmd << '--include-partial-messages' if @options.include_partial_messages
-      cmd << '--fork-session' if @options.fork_session
-      cmd << '--bare' if @options.bare
-
-      # Note: agents are now sent via the initialize control request (not CLI args)
-      # to avoid OS ARG_MAX limits with large agent configurations.
-
-      # Plugins
-      build_plugins_args(cmd)
-
-      # Setting sources
-      if @options.setting_sources
-        cmd.concat(['--setting-sources', @options.setting_sources.join(',')])
-      end
-
-      # Extra args
-      @options.extra_args.each do |flag, value|
-        flag_str = flag.to_s
-        unless EXTRA_ARG_FLAG_RE.match?(flag_str)
-          raise ArgumentError, "Invalid extra_args flag name: #{flag.inspect} (expected lowercase kebab-case)"
-        end
-
-        if value.nil?
-          cmd << "--#{flag_str}"
-        else
-          cmd.concat(["--#{flag_str}", value.to_s])
-        end
-      end
-
-      # Always use streaming mode for bidirectional control protocol.
-      # Prompts and agents are sent via stdin (initialize + user messages),
-      # which avoids OS ARG_MAX limits for large prompts and agent configurations.
-      cmd.concat(['--input-format', 'stream-json'])
-
-      cmd
+      CommandBuilder.new(@cli_path, @options).build
     end
 
     def connect
@@ -513,124 +394,6 @@ module ClaudeAgentSDK
 
     def ready?
       @ready
-    end
-
-    private
-
-    def build_settings_args(cmd)
-      return unless @options.settings || @options.sandbox
-
-      settings_hash = {}
-      settings_is_path = false
-
-      if @options.settings
-        if @options.settings.is_a?(String)
-          begin
-            settings_hash = JSON.parse(@options.settings)
-          rescue JSON::ParserError
-            if @options.sandbox
-              settings_hash = load_settings_file(@options.settings)
-            else
-              settings_is_path = true
-              cmd.concat(['--settings', @options.settings])
-            end
-          end
-        elsif @options.settings.is_a?(Hash)
-          settings_hash = @options.settings.dup
-        end
-      end
-
-      if !settings_is_path && @options.sandbox
-        sandbox_hash = @options.sandbox.is_a?(SandboxSettings) ? @options.sandbox.to_h : @options.sandbox
-        settings_hash[:sandbox] = sandbox_hash unless sandbox_hash.empty?
-      end
-
-      cmd.concat(['--settings', JSON.generate(settings_hash)]) if !settings_is_path && !settings_hash.empty?
-    end
-
-    def build_tools_args(cmd)
-      return if @options.tools.nil?
-
-      if @options.tools.is_a?(Array)
-        tools_value = @options.tools.empty? ? '' : @options.tools.join(',')
-        cmd.concat(['--tools', tools_value])
-      elsif @options.tools.is_a?(ToolsPreset)
-        cmd.concat(['--tools', 'default'])
-      elsif @options.tools.is_a?(Hash)
-        if (@options.tools[:type] || @options.tools['type']) == 'preset'
-          cmd.concat(['--tools', 'default'])
-        else
-          cmd.concat(['--tools', JSON.generate(@options.tools)])
-        end
-      end
-    end
-
-    def build_output_format_args(cmd)
-      return unless @options.output_format
-
-      schema = if @options.output_format.is_a?(Hash) && @options.output_format[:type] == 'json_schema'
-                 @options.output_format[:schema]
-               elsif @options.output_format.is_a?(Hash) && @options.output_format['type'] == 'json_schema'
-                 @options.output_format['schema']
-               else
-                 @options.output_format
-               end
-      schema_json = schema.is_a?(String) ? schema : JSON.generate(schema)
-      cmd.concat(['--json-schema', schema_json])
-    end
-
-    def build_mcp_servers_args(cmd)
-      return unless @options.mcp_servers && !@options.mcp_servers.empty?
-
-      if @options.mcp_servers.is_a?(Hash)
-        servers_for_cli = {}
-        @options.mcp_servers.each do |name, config|
-          servers_for_cli[name] = if config.is_a?(Hash) && config[:type] == 'sdk'
-                                    config.reject { |k, _| k == :instance }
-                                  else
-                                    config
-                                  end
-        end
-        cmd.concat(['--mcp-config', JSON.generate({ mcpServers: servers_for_cli })]) unless servers_for_cli.empty?
-      else
-        cmd.concat(['--mcp-config', @options.mcp_servers.to_s])
-      end
-    end
-
-    def build_plugins_args(cmd)
-      return unless @options.plugins && !@options.plugins.empty?
-
-      @options.plugins.each do |plugin|
-        plugin_config = plugin.is_a?(SdkPluginConfig) ? plugin.to_h : plugin
-        plugin_type = plugin_config[:type] || plugin_config['type']
-        plugin_path = plugin_config[:path] || plugin_config['path']
-
-        raise ArgumentError, "Unsupported plugin type: #{plugin_type.inspect}" unless %w[local plugin].include?(plugin_type)
-        next unless plugin_path
-
-        cmd.concat(['--plugin-dir', plugin_path])
-      end
-    end
-
-    def load_settings_file(path)
-      raise CLIConnectionError, "Settings file not found: #{path}" unless File.file?(path)
-
-      JSON.parse(File.read(path))
-    end
-
-    def build_thinking_args(cmd)
-      if @options.thinking
-        case @options.thinking
-        when ThinkingConfigAdaptive
-          cmd.concat(['--thinking', 'adaptive'])
-        when ThinkingConfigEnabled
-          cmd.concat(['--max-thinking-tokens', @options.thinking.budget_tokens.to_s])
-        when ThinkingConfigDisabled
-          cmd.concat(['--thinking', 'disabled'])
-        end
-      elsif @options.max_thinking_tokens
-        cmd.concat(['--max-thinking-tokens', @options.max_thinking_tokens.to_s])
-      end
     end
   end
 end

--- a/spec/unit/command_builder_spec.rb
+++ b/spec/unit/command_builder_spec.rb
@@ -1,0 +1,316 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ClaudeAgentSDK::CommandBuilder do
+  subject(:cmd) { described_class.new('/usr/bin/claude', options).build }
+
+  let(:options) { ClaudeAgentSDK::ClaudeAgentOptions.new }
+
+  describe '#build' do
+    it 'starts with cli_path and fixed base flags' do
+      expect(cmd[0..3]).to eq(['/usr/bin/claude', '--output-format', 'stream-json', '--verbose'])
+    end
+
+    it 'always appends --input-format stream-json at the end' do
+      expect(cmd.last(2)).to eq(['--input-format', 'stream-json'])
+    end
+
+    it 'emits an empty --system-prompt when system_prompt is nil' do
+      idx = cmd.index('--system-prompt')
+      expect(idx).not_to be_nil
+      expect(cmd[idx + 1]).to eq('')
+    end
+  end
+
+  describe 'system_prompt variants' do
+    it 'handles String' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(system_prompt: 'Hello')
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--system-prompt', 'Hello')
+    end
+
+    it 'handles SystemPromptFile' do
+      prompt = ClaudeAgentSDK::SystemPromptFile.new(path: '/tmp/prompt.txt')
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(system_prompt: prompt)
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--system-prompt-file', '/tmp/prompt.txt')
+      expect(cmd).not_to include('--system-prompt')
+    end
+
+    it 'handles SystemPromptPreset with append' do
+      preset = ClaudeAgentSDK::SystemPromptPreset.new(preset: 'claude_code', append: 'Extra')
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(system_prompt: preset)
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--append-system-prompt', 'Extra')
+      expect(cmd).not_to include('--system-prompt')
+    end
+
+    it 'omits --append-system-prompt for preset with no append' do
+      preset = ClaudeAgentSDK::SystemPromptPreset.new(preset: 'claude_code')
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(system_prompt: preset)
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).not_to include('--append-system-prompt')
+      expect(cmd).not_to include('--system-prompt')
+    end
+
+    it 'handles Hash with type file' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(
+        system_prompt: { type: 'file', path: '/tmp/prompt.txt' }
+      )
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--system-prompt-file', '/tmp/prompt.txt')
+    end
+
+    it 'handles Hash with string keys for type preset' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(
+        system_prompt: { 'type' => 'preset', 'append' => 'Extra' }
+      )
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--append-system-prompt', 'Extra')
+    end
+  end
+
+  describe 'tools' do
+    it 'skips --tools when nil' do
+      expect(cmd).not_to include('--tools')
+    end
+
+    it 'passes array values joined by commas' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(tools: %w[Read Write])
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--tools', 'Read,Write')
+    end
+
+    it 'passes empty string for an empty array' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(tools: [])
+      cmd = described_class.new('/usr/bin/claude', options).build
+      idx = cmd.index('--tools')
+      expect(cmd[idx + 1]).to eq('')
+    end
+
+    it 'passes default for ToolsPreset' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(tools: ClaudeAgentSDK::ToolsPreset.new(preset: 'default'))
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--tools', 'default')
+    end
+
+    it 'passes default for Hash preset' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(tools: { type: 'preset' })
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--tools', 'default')
+    end
+  end
+
+  describe 'allow/disallow/append lists' do
+    it 'joins allowed_tools with commas' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(allowed_tools: %w[Read Write])
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--allowedTools', 'Read,Write')
+    end
+
+    it 'joins disallowed_tools with commas' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(disallowed_tools: %w[Bash])
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--disallowedTools', 'Bash')
+    end
+
+    it 'joins append_allowed_tools with commas' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(append_allowed_tools: %w[Edit])
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--append-allowed-tools', 'Edit')
+    end
+
+    it 'omits empty allowed_tools' do
+      expect(cmd).not_to include('--allowedTools')
+    end
+  end
+
+  describe 'session flags' do
+    it 'adds --continue when continue_conversation is true' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(continue_conversation: true)
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--continue')
+    end
+
+    it 'passes --resume with session id' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(resume: 'abc-123')
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--resume', 'abc-123')
+    end
+
+    it 'passes --session-id' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(session_id: 'sess-xyz')
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--session-id', 'sess-xyz')
+    end
+  end
+
+  describe 'thinking config' do
+    it 'passes adaptive' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(thinking: ClaudeAgentSDK::ThinkingConfigAdaptive.new)
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--thinking', 'adaptive')
+      expect(cmd).not_to include('--max-thinking-tokens')
+    end
+
+    it 'passes --max-thinking-tokens for enabled budget' do
+      thinking = ClaudeAgentSDK::ThinkingConfigEnabled.new(budget_tokens: 50_000)
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(thinking: thinking)
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--max-thinking-tokens', '50000')
+    end
+
+    it 'passes disabled' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(thinking: ClaudeAgentSDK::ThinkingConfigDisabled.new)
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--thinking', 'disabled')
+    end
+
+    it 'falls back to max_thinking_tokens when thinking is nil' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(max_thinking_tokens: 10_000)
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--max-thinking-tokens', '10000')
+    end
+
+    it 'prefers thinking over deprecated max_thinking_tokens' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(
+        thinking: ClaudeAgentSDK::ThinkingConfigAdaptive.new,
+        max_thinking_tokens: 10_000
+      )
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--thinking', 'adaptive')
+      expect(cmd).not_to include('--max-thinking-tokens')
+    end
+  end
+
+  describe 'mcp_servers' do
+    it 'serializes Hash to --mcp-config JSON' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(
+        mcp_servers: { 'local' => { command: 'node', args: ['server.js'] } }
+      )
+      cmd = described_class.new('/usr/bin/claude', options).build
+      idx = cmd.index('--mcp-config')
+      parsed = JSON.parse(cmd[idx + 1])
+      expect(parsed['mcpServers']['local']['command']).to eq('node')
+    end
+
+    it 'strips :instance from SDK MCP server configs' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(
+        mcp_servers: { 'sdk' => { type: 'sdk', name: 'sdk', instance: Object.new } }
+      )
+      cmd = described_class.new('/usr/bin/claude', options).build
+      idx = cmd.index('--mcp-config')
+      expect(cmd[idx + 1]).not_to include('instance')
+    end
+  end
+
+  describe 'extra_args' do
+    it 'passes boolean flags with no value' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(extra_args: { 'debug-to-stderr' => nil })
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--debug-to-stderr')
+    end
+
+    it 'passes flags with value' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(extra_args: { 'log-level' => 'debug' })
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--log-level', 'debug')
+    end
+
+    it 'accepts symbol keys' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(extra_args: { debug: nil })
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--debug')
+    end
+
+    it 'rejects keys with spaces' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(
+        extra_args: { 'bad flag' => nil }
+      )
+      expect { described_class.new('/usr/bin/claude', options).build }
+        .to raise_error(ArgumentError, /Invalid extra_args flag name/)
+    end
+
+    it 'rejects keys starting with --' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(
+        extra_args: { '--prefixed' => nil }
+      )
+      expect { described_class.new('/usr/bin/claude', options).build }
+        .to raise_error(ArgumentError, /Invalid extra_args flag name/)
+    end
+  end
+
+  describe 'plugins' do
+    it 'emits --plugin-dir per plugin' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(
+        plugins: [
+          { type: 'local', path: '/tmp/plugin-a' },
+          { type: 'plugin', path: '/tmp/plugin-b' }
+        ]
+      )
+      cmd = described_class.new('/usr/bin/claude', options).build
+      paths = []
+      cmd.each_with_index do |arg, i|
+        paths << cmd[i + 1] if arg == '--plugin-dir'
+      end
+      expect(paths).to eq(['/tmp/plugin-a', '/tmp/plugin-b'])
+    end
+
+    it 'raises on unsupported plugin type' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(
+        plugins: [{ type: 'remote', path: '/tmp/x' }]
+      )
+      expect { described_class.new('/usr/bin/claude', options).build }
+        .to raise_error(ArgumentError, /Unsupported plugin type/)
+    end
+  end
+
+  describe 'settings + sandbox merge' do
+    it 'merges a SandboxSettings into an inline settings hash' do
+      sandbox = ClaudeAgentSDK::SandboxSettings.new(enabled: true)
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(
+        settings: { existingKey: 'value' },
+        sandbox: sandbox
+      )
+      cmd = described_class.new('/usr/bin/claude', options).build
+      idx = cmd.index('--settings')
+      parsed = JSON.parse(cmd[idx + 1])
+      expect(parsed['existingKey']).to eq('value')
+      expect(parsed['sandbox']).to include('enabled' => true)
+    end
+
+    it 'treats unparseable settings strings as file paths when no sandbox' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(settings: '/path/to/settings.json')
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--settings', '/path/to/settings.json')
+    end
+  end
+
+  describe 'boolean flags' do
+    it 'passes --include-partial-messages' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(include_partial_messages: true)
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--include-partial-messages')
+    end
+
+    it 'passes --fork-session' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(fork_session: true)
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--fork-session')
+    end
+
+    it 'passes --bare' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(bare: true)
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--bare')
+    end
+  end
+
+  describe 'standalone loading' do
+    it 'CommandBuilder can be required on its own' do
+      output = `#{RbConfig.ruby} -Ilib -rclaude_agent_sdk/command_builder -e "puts ClaudeAgentSDK::CommandBuilder.name" 2>&1`
+      expect(output.strip).to eq('ClaudeAgentSDK::CommandBuilder')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Introduce `ClaudeAgentSDK::CommandBuilder` (`lib/claude_agent_sdk/command_builder.rb`) that owns the CLI argv assembly previously inlined in `SubprocessCLITransport`.
- `SubprocessCLITransport#build_command` now delegates to `CommandBuilder.new(@cli_path, @options).build`, and the private `build_*_args` helpers plus `EXTRA_ARG_FLAG_RE` move out of the transport.
- Builder stores the command as `@cmd` so each `append_*` step reads as a self-contained phase, uses `push` (never `concat` or `<<`), and keeps double-quoted string literals.

## Test plan
- [x] `bundle exec rspec` (570 examples, 0 failures)