### PR TITLE
Extract writeln/write helpers for transport writes

### DIFF
--- a/lib/claude_agent_sdk.rb
+++ b/lib/claude_agent_sdk.rb
@@ -374,9 +374,7 @@ module ClaudeAgentSDK
         query(prompt)
       else
         prompt.each do |message_json|
-          message_json = message_json.to_s
-          message_json += "\n" unless message_json.end_with?("\n")
-          @transport.write(message_json)
+          writeln(message_json.to_s)
         end
       end
     end
@@ -394,7 +392,7 @@ module ClaudeAgentSDK
         parent_tool_use_id: nil,
         session_id: session_id
       }
-      @transport.write(JSON.generate(message) + "\n")
+      writeln(JSON.generate(message))
     end
 
     # Receive all messages from Claude
@@ -553,6 +551,14 @@ module ClaudeAgentSDK
         end
       end
       nil
+    end
+
+    def writeln(string)
+      write string.end_with?("\n") ? string : "#{string}\n"
+    end
+
+    def write(string)
+      @transport.write(string)
     end
   end
 end

--- a/lib/claude_agent_sdk/query.rb
+++ b/lib/claude_agent_sdk/query.rb
@@ -261,7 +261,7 @@ module ClaudeAgentSDK
           response: response_data
         }
       }
-      @transport.write(JSON.generate(success_response) + "\n")
+      writeln(JSON.generate(success_response))
     rescue Async::Stop
       # Cancellation requested; respond with an error so the CLI can unblock.
       cancelled_response = {
@@ -273,7 +273,7 @@ module ClaudeAgentSDK
           error: 'Cancelled'
         }
       }
-      @transport.write(JSON.generate(cancelled_response) + "\n")
+      writeln(JSON.generate(cancelled_response))
     rescue StandardError => e
       # Send error response
       error_response = {
@@ -285,7 +285,7 @@ module ClaudeAgentSDK
           error: e.message
         }
       }
-      @transport.write(JSON.generate(error_response) + "\n")
+      writeln(JSON.generate(error_response))
     end
 
     def handle_permission_request(request_data)
@@ -642,7 +642,7 @@ module ClaudeAgentSDK
         request: request
       }
 
-      @transport.write(JSON.generate(control_request) + "\n")
+      writeln(JSON.generate(control_request))
 
       # Wait for response with timeout (default 1200s to handle slow CLI startup)
       Async do |task|
@@ -913,19 +913,22 @@ module ClaudeAgentSDK
     def stream_input(stream)
       stream.each do |message|
         break if @closed
-        serialized = if message.is_a?(Hash)
-                       JSON.generate(message) + "\n"
-                     else
-                       message.to_s
-                     end
-        serialized += "\n" unless serialized.end_with?("\n")
-        @transport.write(serialized)
+        serialized = message.is_a?(Hash) ? JSON.generate(message) : message.to_s
+        writeln(serialized)
       end
     rescue StandardError => e
       # Log error but don't raise
       warn "Error streaming input: #{e.message}"
     ensure
       wait_for_result_and_end_input
+    end
+
+    def writeln(string)
+      write string.end_with?("\n") ? string : "#{string}\n"
+    end
+
+    def write(string)
+      @transport.write(string)
     end
 
     # Receive SDK messages (not control messages)


### PR DESCRIPTION
## Summary
- Extract private `writeln`/`write` helpers in `Client` and `Query` to consolidate the `@transport.write(json + "\n")` pattern
- Simplify `stream_input` and the initial prompt loop now that newline handling is centralized

## Test plan
- [x] `bundle exec rspec`
- [ ] `bundle exec rubocop`