### PR TITLE
Unify types under Type base class

### DIFF
--- a/lib/claude_agent_sdk/message_parser.rb
+++ b/lib/claude_agent_sdk/message_parser.rb
@@ -78,214 +78,57 @@ module ClaudeAgentSDK
       )
     end
 
+    # Typed SystemMessage subclasses inherit from `Type` and accept the raw
+    # CLI hash directly — camelCase and snake_case keys are normalized by the
+    # base class, and the full hash is captured as `#data`.
+    SYSTEM_MESSAGE_CLASSES = {
+      'init' => InitMessage,
+      'compact_boundary' => CompactBoundaryMessage,
+      'status' => StatusMessage,
+      'api_retry' => APIRetryMessage,
+      'local_command_output' => LocalCommandOutputMessage,
+      'hook_started' => HookStartedMessage,
+      'hook_progress' => HookProgressMessage,
+      'hook_response' => HookResponseMessage,
+      'session_state_changed' => SessionStateChangedMessage,
+      'files_persisted' => FilesPersistedMessage,
+      'elicitation_complete' => ElicitationCompleteMessage,
+      'task_started' => TaskStartedMessage,
+      'task_progress' => TaskProgressMessage,
+      'task_notification' => TaskNotificationMessage
+    }.freeze
+
     def self.parse_system_message(data)
-      case data[:subtype]
-      when 'init'
-        InitMessage.new(
-          subtype: data[:subtype], data: data,
-          uuid: data[:uuid], session_id: data[:session_id],
-          agents: data[:agents], api_key_source: data[:apiKeySource] || data[:api_key_source],
-          betas: data[:betas], claude_code_version: data[:claude_code_version],
-          cwd: data[:cwd], tools: data[:tools], mcp_servers: data[:mcp_servers],
-          model: data[:model], permission_mode: data[:permissionMode] || data[:permission_mode],
-          slash_commands: data[:slash_commands], output_style: data[:output_style],
-          skills: data[:skills], plugins: data[:plugins],
-          fast_mode_state: data[:fastModeState] || data[:fast_mode_state]
-        )
-      when 'compact_boundary'
-        raw_metadata = data[:compact_metadata]
-        CompactBoundaryMessage.new(
-          subtype: data[:subtype], data: data,
-          uuid: data[:uuid], session_id: data[:session_id],
-          compact_metadata: CompactMetadata.from_hash(raw_metadata)
-        )
-      when 'status'
-        StatusMessage.new(
-          subtype: data[:subtype], data: data,
-          uuid: data[:uuid], session_id: data[:session_id],
-          status: data[:status],
-          permission_mode: data[:permissionMode] || data[:permission_mode]
-        )
-      when 'api_retry'
-        APIRetryMessage.new(
-          subtype: data[:subtype], data: data,
-          uuid: data[:uuid], session_id: data[:session_id],
-          attempt: data[:attempt], max_retries: data[:maxRetries] || data[:max_retries],
-          retry_delay_ms: data[:retryDelayMs] || data[:retry_delay_ms],
-          error_status: data[:errorStatus] || data[:error_status],
-          error: data[:error]
-        )
-      when 'local_command_output'
-        LocalCommandOutputMessage.new(
-          subtype: data[:subtype], data: data,
-          uuid: data[:uuid], session_id: data[:session_id],
-          content: data[:content]
-        )
-      when 'hook_started'
-        HookStartedMessage.new(
-          subtype: data[:subtype], data: data,
-          uuid: data[:uuid], session_id: data[:session_id],
-          hook_id: data[:hookId] || data[:hook_id],
-          hook_name: data[:hookName] || data[:hook_name],
-          hook_event: data[:hookEvent] || data[:hook_event]
-        )
-      when 'hook_progress'
-        HookProgressMessage.new(
-          subtype: data[:subtype], data: data,
-          uuid: data[:uuid], session_id: data[:session_id],
-          hook_id: data[:hookId] || data[:hook_id],
-          hook_name: data[:hookName] || data[:hook_name],
-          hook_event: data[:hookEvent] || data[:hook_event],
-          stdout: data[:stdout], stderr: data[:stderr], output: data[:output]
-        )
-      when 'hook_response'
-        HookResponseMessage.new(
-          subtype: data[:subtype], data: data,
-          uuid: data[:uuid], session_id: data[:session_id],
-          hook_id: data[:hookId] || data[:hook_id],
-          hook_name: data[:hookName] || data[:hook_name],
-          hook_event: data[:hookEvent] || data[:hook_event],
-          output: data[:output], stdout: data[:stdout], stderr: data[:stderr],
-          exit_code: data[:exitCode] || data[:exit_code],
-          outcome: data[:outcome]
-        )
-      when 'session_state_changed'
-        SessionStateChangedMessage.new(
-          subtype: data[:subtype], data: data,
-          uuid: data[:uuid], session_id: data[:session_id],
-          state: data[:state]
-        )
-      when 'files_persisted'
-        FilesPersistedMessage.new(
-          subtype: data[:subtype], data: data,
-          uuid: data[:uuid], session_id: data[:session_id],
-          files: data[:files], failed: data[:failed],
-          processed_at: data[:processedAt] || data[:processed_at]
-        )
-      when 'elicitation_complete'
-        ElicitationCompleteMessage.new(
-          subtype: data[:subtype], data: data,
-          uuid: data[:uuid], session_id: data[:session_id],
-          mcp_server_name: data[:mcpServerName] || data[:mcp_server_name],
-          elicitation_id: data[:elicitationId] || data[:elicitation_id]
-        )
-      when 'task_started'
-        TaskStartedMessage.new(
-          subtype: data[:subtype], data: data,
-          task_id: data[:task_id], description: data[:description],
-          uuid: data[:uuid], session_id: data[:session_id],
-          tool_use_id: data[:tool_use_id], task_type: data[:task_type],
-          workflow_name: data[:workflowName] || data[:workflow_name],
-          prompt: data[:prompt]
-        )
-      when 'task_progress'
-        TaskProgressMessage.new(
-          subtype: data[:subtype], data: data,
-          task_id: data[:task_id], description: data[:description],
-          usage: data[:usage], uuid: data[:uuid], session_id: data[:session_id],
-          tool_use_id: data[:tool_use_id], last_tool_name: data[:last_tool_name],
-          summary: data[:summary]
-        )
-      when 'task_notification'
-        TaskNotificationMessage.new(
-          subtype: data[:subtype], data: data,
-          task_id: data[:task_id], status: data[:status],
-          output_file: data[:output_file], summary: data[:summary],
-          uuid: data[:uuid], session_id: data[:session_id],
-          tool_use_id: data[:tool_use_id], usage: data[:usage]
-        )
-      else
-        SystemMessage.new(subtype: data[:subtype], data: data)
-      end
+      klass = SYSTEM_MESSAGE_CLASSES[data[:subtype]] || SystemMessage
+      klass.new(data)
     end
 
     def self.parse_result_message(data)
-      ResultMessage.new(
-        subtype: data[:subtype],
-        duration_ms: data[:duration_ms],
-        duration_api_ms: data[:duration_api_ms],
-        is_error: data[:is_error],
-        num_turns: data[:num_turns],
-        session_id: data[:session_id],
-        stop_reason: data[:stop_reason],
-        total_cost_usd: data[:total_cost_usd],
-        usage: data[:usage],
-        result: data[:result],
-        structured_output: data[:structured_output],
-        model_usage: data[:modelUsage] || data[:model_usage],
-        permission_denials: data[:permission_denials],
-        errors: data[:errors],
-        uuid: data[:uuid],
-        fast_mode_state: data[:fastModeState] || data[:fast_mode_state]
-      )
+      ResultMessage.new(data)
     end
 
     def self.parse_stream_event(data)
-      StreamEvent.new(
-        uuid: data[:uuid],
-        session_id: data[:session_id],
-        event: data[:event],
-        parent_tool_use_id: data[:parent_tool_use_id]
-      )
+      StreamEvent.new(data)
     end
 
     def self.parse_rate_limit_event(data)
-      info = data[:rate_limit_info] || {}
-      rate_limit_info = RateLimitInfo.new(
-        status: info[:status],
-        resets_at: info[:resetsAt],
-        rate_limit_type: info[:rateLimitType],
-        utilization: info[:utilization],
-        overage_status: info[:overageStatus],
-        overage_resets_at: info[:overageResetsAt],
-        overage_disabled_reason: info[:overageDisabledReason],
-        raw: info
-      )
-      RateLimitEvent.new(
-        rate_limit_info: rate_limit_info,
-        uuid: data[:uuid],
-        session_id: data[:session_id],
-        raw_data: data
-      )
+      RateLimitEvent.new(data.merge(raw_data: data))
     end
 
     def self.parse_tool_progress_message(data)
-      ToolProgressMessage.new(
-        uuid: data[:uuid],
-        session_id: data[:session_id],
-        tool_use_id: data[:toolUseId] || data[:tool_use_id],
-        tool_name: data[:toolName] || data[:tool_name],
-        parent_tool_use_id: data[:parentToolUseId] || data[:parent_tool_use_id],
-        elapsed_time_seconds: data[:elapsedTimeSeconds] || data[:elapsed_time_seconds],
-        task_id: data[:taskId] || data[:task_id]
-      )
+      ToolProgressMessage.new(data)
     end
 
     def self.parse_auth_status_message(data)
-      AuthStatusMessage.new(
-        uuid: data[:uuid],
-        session_id: data[:session_id],
-        is_authenticating: data[:isAuthenticating] || data[:is_authenticating],
-        output: data[:output],
-        error: data[:error]
-      )
+      AuthStatusMessage.new(data)
     end
 
     def self.parse_tool_use_summary_message(data)
-      ToolUseSummaryMessage.new(
-        uuid: data[:uuid],
-        session_id: data[:session_id],
-        summary: data[:summary],
-        preceding_tool_use_ids: data[:precedingToolUseIds] || data[:preceding_tool_use_ids]
-      )
+      ToolUseSummaryMessage.new(data)
     end
 
     def self.parse_prompt_suggestion_message(data)
-      PromptSuggestionMessage.new(
-        uuid: data[:uuid],
-        session_id: data[:session_id],
-        suggestion: data[:suggestion]
-      )
+      PromptSuggestionMessage.new(data)
     end
 
     # Accepts blocks with either symbol or string keys — live CLI messages

--- a/lib/claude_agent_sdk/types.rb
+++ b/lib/claude_agent_sdk/types.rb
@@ -57,80 +57,150 @@ module ClaudeAgentSDK
   # Available beta features that can be enabled via the betas option
   SDK_BETAS = %w[context-1m-2025-08-07].freeze
 
+  # Base class for all types.
+  class Type
+    def self.wrap(object)
+      case object
+      when self
+        object
+      else
+        new(object)
+      end
+    end
+
+    def self.from_hash(hash)
+      return unless hash.is_a?(Hash)
+
+      new(hash)
+    end
+
+    def initialize(attributes = {})
+      assign_attributes(attributes) if attributes
+      super()
+    end
+
+    def [](name)
+      read_attribute(name)
+    end
+
+    def []=(name, value)
+      assign_attribute(name, value)
+    end
+
+    # Subclasses should override this to return a hash representation of the object.
+    def to_h
+      {}
+    end
+
+    private
+
+    # Allow camelCase attribute access
+    def method_missing(method_name, ...)
+      normalized = normalize_name(method_name)
+
+      if normalized != method_name.to_s && respond_to?(normalized)
+        public_send(normalized, ...)
+      else
+        super
+      end
+    end
+
+    def respond_to_missing?(method_name, include_private = false)
+      normalized = normalize_name(method_name)
+      (normalized != method_name.to_s && respond_to?(normalized)) || super
+    end
+
+    def assign_attributes(attributes)
+      raise ArgumentError, "When assigning attributes, you must pass a hash as an argument, #{attributes.inspect} passed." unless attributes.respond_to?(:each_pair)
+
+      return if attributes.empty?
+
+      attributes.each_pair { |name, value| assign_attribute(name, value) }
+    end
+
+    def assign_attribute(name, value)
+      setter = :"#{normalize_name(name)}="
+      public_send(setter, value) if respond_to?(setter)
+    end
+
+    def read_attribute(name)
+      getter = normalize_name(name)
+      public_send(getter) if respond_to?(getter)
+    end
+
+    def normalize_name(name)
+      name = name.dup.to_s
+      name.gsub!(/(?<=[A-Z])(?=[A-Z][a-z])|(?<=[a-z\d])(?=[A-Z])/, "_")
+      name.tr!("-", "_")
+      name.downcase!
+      name
+    end
+
+    FALSE_VALUES = [
+      false, 0,
+      "0", :"0",
+      "f", :f,
+      "F", :F,
+      "false", :false,
+      "FALSE", :FALSE,
+      "off", :off,
+      "OFF", :OFF,
+    ].to_set.freeze
+
+    private_constant :FALSE_VALUES
+
+    def coerce_boolean(value)
+      return if value.nil?
+
+      if value == ""
+        nil
+      else
+        !FALSE_VALUES.include?(value)
+      end
+    end
+  end
+
   # Content Blocks
 
   # Text content block
-  class TextBlock
+  class TextBlock < Type
     attr_accessor :text
-
-    def initialize(text:)
-      @text = text
-    end
   end
 
   # Thinking content block
-  class ThinkingBlock
+  class ThinkingBlock < Type
     attr_accessor :thinking, :signature
-
-    def initialize(thinking:, signature:)
-      @thinking = thinking
-      @signature = signature
-    end
   end
 
   # Tool use content block
-  class ToolUseBlock
+  class ToolUseBlock < Type
     attr_accessor :id, :name, :input
-
-    def initialize(id:, name:, input:)
-      @id = id
-      @name = name
-      @input = input
-    end
   end
 
   # Tool result content block
-  class ToolResultBlock
+  class ToolResultBlock < Type
     attr_accessor :tool_use_id, :content, :is_error
-
-    def initialize(tool_use_id:, content: nil, is_error: nil)
-      @tool_use_id = tool_use_id
-      @content = content
-      @is_error = is_error
-    end
   end
 
   # Generic content block for types the SDK doesn't explicitly handle (e.g., "document", "image").
   # Preserves the raw hash data for forward compatibility with newer CLI versions.
-  class UnknownBlock
+  class UnknownBlock < Type
     attr_accessor :type, :data
-
-    def initialize(type:, data:)
-      @type = type
-      @data = data
-    end
   end
 
   # Message Types
 
   # User message
-  class UserMessage
+  class UserMessage < Type
     attr_accessor :content, :uuid, :parent_tool_use_id, :tool_use_result
-
-    def initialize(content:, uuid: nil, parent_tool_use_id: nil, tool_use_result: nil)
-      @content = content
-      @uuid = uuid # Unique identifier for rewind support
-      @parent_tool_use_id = parent_tool_use_id
-      @tool_use_result = tool_use_result # Tool result data when message is a tool response
-    end
 
     # Concatenated text of this message. Handles both String content
     # (plain-text user prompt) and Array-of-blocks content (typed content).
     # Returns "" when there is no text.
     def text
-      case @content
-      when String then @content
-      when Array then @content.grep(TextBlock).map(&:text).join("\n\n")
+      case content
+      when String then content
+      when Array then content.grep(TextBlock).map(&:text).join("\n\n")
       else ''
       end
     end
@@ -139,39 +209,28 @@ module ClaudeAgentSDK
   end
 
   # Assistant message with content blocks
-  class AssistantMessage
+  class AssistantMessage < Type
     attr_accessor :content, :model, :parent_tool_use_id, :error, :usage,
                   :message_id, :stop_reason, :session_id, :uuid
-
-    def initialize(content:, model:, parent_tool_use_id: nil, error: nil, usage: nil,
-                   message_id: nil, stop_reason: nil, session_id: nil, uuid: nil)
-      @content = content
-      @model = model
-      @parent_tool_use_id = parent_tool_use_id
-      @error = error # One of: authentication_failed, billing_error, rate_limit, invalid_request, server_error, unknown
-      @usage = usage # Token usage info from the API response
-      @message_id = message_id # Unique message identifier from the API (message.id)
-      @stop_reason = stop_reason # Why the assistant stopped (e.g., "end_turn", "max_tokens")
-      @session_id = session_id # Session the message belongs to
-      @uuid = uuid # Unique message UUID in the session transcript
-    end
 
     # Concatenated text across every TextBlock in this message's content.
     # Returns "" when the message has no text (e.g., a pure tool_use turn).
     def text
-      Array(@content).grep(TextBlock).map(&:text).join("\n\n")
+      Array(content).grep(TextBlock).map(&:text).join("\n\n")
     end
 
     alias to_s text
   end
 
-  # System message with metadata
-  class SystemMessage
+  # System message with metadata.
+  # When constructed from a raw CLI hash, the whole hash is stored in `#data`
+  # unless the caller explicitly provides a `:data` entry.
+  class SystemMessage < Type
     attr_accessor :subtype, :data
 
-    def initialize(subtype:, data:)
-      @subtype = subtype
-      @data = data
+    def initialize(attributes = {})
+      super
+      @data ||= attributes if attributes.is_a?(Hash)
     end
   end
 
@@ -180,229 +239,84 @@ module ClaudeAgentSDK
     attr_accessor :uuid, :session_id, :agents, :api_key_source, :betas,
                   :claude_code_version, :cwd, :tools, :mcp_servers, :model,
                   :permission_mode, :slash_commands, :output_style, :skills, :plugins,
-                  :fast_mode_state
-
-    def initialize(subtype:, data:, uuid: nil, session_id: nil, agents: nil,
-                   api_key_source: nil, betas: nil, claude_code_version: nil,
-                   cwd: nil, tools: nil, mcp_servers: nil, model: nil,
-                   permission_mode: nil, slash_commands: nil, output_style: nil,
-                   skills: nil, plugins: nil, fast_mode_state: nil)
-      super(subtype: subtype, data: data)
-      @uuid = uuid
-      @session_id = session_id
-      @agents = agents
-      @api_key_source = api_key_source
-      @betas = betas
-      @claude_code_version = claude_code_version
-      @cwd = cwd
-      @tools = tools
-      @mcp_servers = mcp_servers
-      @model = model
-      @permission_mode = permission_mode
-      @slash_commands = slash_commands
-      @output_style = output_style
-      @skills = skills
-      @plugins = plugins
-      @fast_mode_state = fast_mode_state # "off", "cooldown", or "on"
-    end
+                  :fast_mode_state # "off", "cooldown", or "on"
   end
 
   # Compact boundary system message (emitted after context compaction completes)
   class CompactBoundaryMessage < SystemMessage
-    attr_accessor :uuid, :session_id, :compact_metadata
+    attr_accessor :uuid, :session_id
+    attr_reader :compact_metadata
 
-    def initialize(subtype:, data:, uuid: nil, session_id: nil, compact_metadata: nil)
-      super(subtype: subtype, data: data)
-      @uuid = uuid
-      @session_id = session_id
-      @compact_metadata = compact_metadata
+    def compact_metadata=(value)
+      @compact_metadata = value.is_a?(Hash) ? CompactMetadata.new(value) : value
     end
   end
 
   # Metadata about a compaction event
-  class CompactMetadata
+  class CompactMetadata < Type
     attr_accessor :pre_tokens, :post_tokens, :trigger, :custom_instructions, :preserved_segment
-
-    def initialize(pre_tokens: nil, post_tokens: nil, trigger: nil, custom_instructions: nil, preserved_segment: nil)
-      @pre_tokens = pre_tokens
-      @post_tokens = post_tokens
-      @trigger = trigger # "manual" or "auto"
-      @custom_instructions = custom_instructions
-      @preserved_segment = preserved_segment # Hash with head_uuid, anchor_uuid, tail_uuid
-    end
-
-    def self.from_hash(hash)
-      return nil unless hash.is_a?(Hash)
-
-      preserved = hash[:preserved_segment] || hash['preserved_segment'] ||
-                  hash[:preservedSegment] || hash['preservedSegment']
-
-      new(
-        pre_tokens: hash[:pre_tokens] || hash['pre_tokens'] || hash[:preTokens] || hash['preTokens'],
-        post_tokens: hash[:post_tokens] || hash['post_tokens'] || hash[:postTokens] || hash['postTokens'],
-        trigger: hash[:trigger] || hash['trigger'],
-        custom_instructions: hash[:custom_instructions] || hash['custom_instructions'] ||
-                             hash[:customInstructions] || hash['customInstructions'],
-        preserved_segment: preserved
-      )
-    end
   end
 
   # Status system message (compacting status, permission mode changes)
   class StatusMessage < SystemMessage
     attr_accessor :uuid, :session_id, :status, :permission_mode
-
-    def initialize(subtype:, data:, uuid: nil, session_id: nil, status: nil, permission_mode: nil)
-      super(subtype: subtype, data: data)
-      @uuid = uuid
-      @session_id = session_id
-      @status = status # "compacting" or nil
-      @permission_mode = permission_mode
-    end
   end
 
   # API retry system message
   class APIRetryMessage < SystemMessage
     attr_accessor :uuid, :session_id, :attempt, :max_retries, :retry_delay_ms, :error_status, :error
-
-    def initialize(subtype:, data:, uuid: nil, session_id: nil, attempt: nil, max_retries: nil,
-                   retry_delay_ms: nil, error_status: nil, error: nil)
-      super(subtype: subtype, data: data)
-      @uuid = uuid
-      @session_id = session_id
-      @attempt = attempt
-      @max_retries = max_retries
-      @retry_delay_ms = retry_delay_ms
-      @error_status = error_status
-      @error = error
-    end
   end
 
   # Local command output system message
   class LocalCommandOutputMessage < SystemMessage
     attr_accessor :uuid, :session_id, :content
-
-    def initialize(subtype:, data:, uuid: nil, session_id: nil, content: nil)
-      super(subtype: subtype, data: data)
-      @uuid = uuid
-      @session_id = session_id
-      @content = content
-    end
   end
 
   # Hook started system message
   class HookStartedMessage < SystemMessage
     attr_accessor :uuid, :session_id, :hook_id, :hook_name, :hook_event
-
-    def initialize(subtype:, data:, uuid: nil, session_id: nil, hook_id: nil, hook_name: nil, hook_event: nil)
-      super(subtype: subtype, data: data)
-      @uuid = uuid
-      @session_id = session_id
-      @hook_id = hook_id
-      @hook_name = hook_name
-      @hook_event = hook_event
-    end
   end
 
   # Hook progress system message
   class HookProgressMessage < SystemMessage
     attr_accessor :uuid, :session_id, :hook_id, :hook_name, :hook_event, :stdout, :stderr, :output
-
-    def initialize(subtype:, data:, uuid: nil, session_id: nil, hook_id: nil, hook_name: nil,
-                   hook_event: nil, stdout: nil, stderr: nil, output: nil)
-      super(subtype: subtype, data: data)
-      @uuid = uuid
-      @session_id = session_id
-      @hook_id = hook_id
-      @hook_name = hook_name
-      @hook_event = hook_event
-      @stdout = stdout
-      @stderr = stderr
-      @output = output
-    end
   end
 
   # Hook response system message
   class HookResponseMessage < SystemMessage
     attr_accessor :uuid, :session_id, :hook_id, :hook_name, :hook_event,
-                  :output, :stdout, :stderr, :exit_code, :outcome
-
-    def initialize(subtype:, data:, uuid: nil, session_id: nil, hook_id: nil, hook_name: nil,
-                   hook_event: nil, output: nil, stdout: nil, stderr: nil, exit_code: nil, outcome: nil)
-      super(subtype: subtype, data: data)
-      @uuid = uuid
-      @session_id = session_id
-      @hook_id = hook_id
-      @hook_name = hook_name
-      @hook_event = hook_event
-      @output = output
-      @stdout = stdout
-      @stderr = stderr
-      @exit_code = exit_code
-      @outcome = outcome # "success", "error", or "cancelled"
-    end
+                  :output, :stdout, :stderr, :exit_code,
+                  :outcome # "success", "error", or "cancelled"
   end
 
   # Session state changed system message
   class SessionStateChangedMessage < SystemMessage
-    attr_accessor :uuid, :session_id, :state
-
-    def initialize(subtype:, data:, uuid: nil, session_id: nil, state: nil)
-      super(subtype: subtype, data: data)
-      @uuid = uuid
-      @session_id = session_id
-      @state = state # "idle", "running", or "requires_action"
-    end
+    attr_accessor :uuid, :session_id,
+                  :state # "idle", "running", or "requires_action"
   end
 
   # Files persisted system message
   class FilesPersistedMessage < SystemMessage
     attr_accessor :uuid, :session_id, :files, :failed, :processed_at
-
-    def initialize(subtype:, data:, uuid: nil, session_id: nil, files: nil, failed: nil, processed_at: nil)
-      super(subtype: subtype, data: data)
-      @uuid = uuid
-      @session_id = session_id
-      @files = files # Array of { filename:, file_id: }
-      @failed = failed # Array of { filename:, error: }
-      @processed_at = processed_at
-    end
   end
 
   # Elicitation complete system message
   class ElicitationCompleteMessage < SystemMessage
     attr_accessor :uuid, :session_id, :mcp_server_name, :elicitation_id
-
-    def initialize(subtype:, data:, uuid: nil, session_id: nil, mcp_server_name: nil, elicitation_id: nil)
-      super(subtype: subtype, data: data)
-      @uuid = uuid
-      @session_id = session_id
-      @mcp_server_name = mcp_server_name
-      @elicitation_id = elicitation_id
-    end
   end
 
   # Task lifecycle notification statuses
   TASK_NOTIFICATION_STATUSES = %w[completed failed stopped].freeze
 
   # Typed usage data for task progress and notifications
-  class TaskUsage
+  class TaskUsage < Type
     attr_accessor :total_tokens, :tool_uses, :duration_ms
 
-    def initialize(total_tokens: 0, tool_uses: 0, duration_ms: 0)
-      @total_tokens = total_tokens
-      @tool_uses = tool_uses
-      @duration_ms = duration_ms
-    end
-
-    def self.from_hash(hash)
-      return nil unless hash.is_a?(Hash)
-
-      new(
-        total_tokens: hash[:total_tokens] || hash['total_tokens'] || hash[:totalTokens] || hash['totalTokens'] || 0,
-        tool_uses: hash[:tool_uses] || hash['tool_uses'] || hash[:toolUses] || hash['toolUses'] || 0,
-        duration_ms: hash[:duration_ms] || hash['duration_ms'] || hash[:durationMs] || hash['durationMs'] || 0
-      )
+    def initialize(attributes = {})
+      super
+      @total_tokens ||= 0
+      @tool_uses    ||= 0
+      @duration_ms  ||= 0
     end
   end
 
@@ -410,151 +324,54 @@ module ClaudeAgentSDK
   class TaskStartedMessage < SystemMessage
     attr_accessor :task_id, :description, :uuid, :session_id, :tool_use_id, :task_type,
                   :workflow_name, :prompt
-
-    def initialize(subtype:, data:, task_id:, description:, uuid:, session_id:,
-                   tool_use_id: nil, task_type: nil, workflow_name: nil, prompt: nil)
-      super(subtype: subtype, data: data)
-      @task_id = task_id
-      @description = description
-      @uuid = uuid
-      @session_id = session_id
-      @tool_use_id = tool_use_id
-      @task_type = task_type
-      @workflow_name = workflow_name
-      @prompt = prompt
-    end
   end
 
   # Task progress system message (periodic update from a running task)
   class TaskProgressMessage < SystemMessage
     attr_accessor :task_id, :description, :usage, :uuid, :session_id, :tool_use_id, :last_tool_name, :summary
-
-    def initialize(subtype:, data:, task_id:, description:, usage:, uuid:, session_id:,
-                   tool_use_id: nil, last_tool_name: nil, summary: nil)
-      super(subtype: subtype, data: data)
-      @task_id = task_id
-      @description = description
-      @usage = usage
-      @uuid = uuid
-      @session_id = session_id
-      @tool_use_id = tool_use_id
-      @last_tool_name = last_tool_name
-      @summary = summary
-    end
   end
 
   # Task notification system message (task completed/failed/stopped)
   class TaskNotificationMessage < SystemMessage
     attr_accessor :task_id, :status, :output_file, :summary, :uuid, :session_id, :tool_use_id, :usage
-
-    def initialize(subtype:, data:, task_id:, status:, output_file:, summary:, uuid:, session_id:,
-                   tool_use_id: nil, usage: nil)
-      super(subtype: subtype, data: data)
-      @task_id = task_id
-      @status = status
-      @output_file = output_file
-      @summary = summary
-      @uuid = uuid
-      @session_id = session_id
-      @tool_use_id = tool_use_id
-      @usage = usage
-    end
   end
 
   # Result message with cost and usage information
-  class ResultMessage
+  class ResultMessage < Type
     attr_accessor :subtype, :duration_ms, :duration_api_ms, :is_error,
                   :num_turns, :session_id, :stop_reason, :total_cost_usd, :usage,
-                  :result, :structured_output, :model_usage, :permission_denials, :errors,
-                  :uuid, :fast_mode_state
-
-    def initialize(subtype:, duration_ms:, duration_api_ms:, is_error:,
-                   num_turns:, session_id:, stop_reason: nil, total_cost_usd: nil,
-                   usage: nil, result: nil, structured_output: nil,
-                   model_usage: nil, permission_denials: nil, errors: nil,
-                   uuid: nil, fast_mode_state: nil)
-      @subtype = subtype
-      @duration_ms = duration_ms
-      @duration_api_ms = duration_api_ms
-      @is_error = is_error
-      @num_turns = num_turns
-      @session_id = session_id
-      @stop_reason = stop_reason
-      @total_cost_usd = total_cost_usd
-      @usage = usage
-      @result = result
-      @structured_output = structured_output
-      @model_usage = model_usage # Hash of { model_name => usage_data }
-      @permission_denials = permission_denials # Array of { tool_name:, tool_use_id:, tool_input: }
-      @errors = errors # Array of error strings (present on error subtypes)
-      @uuid = uuid
-      @fast_mode_state = fast_mode_state # "off", "cooldown", or "on"
-    end
+                  :result, :structured_output,
+                  :model_usage,        # Hash of { model_name => usage_data }
+                  :permission_denials, # Array of { tool_name:, tool_use_id:, tool_input: }
+                  :errors,             # Array of error strings (present on error subtypes)
+                  :uuid,
+                  :fast_mode_state     # "off", "cooldown", or "on"
   end
 
   # Stream event for partial message updates
-  class StreamEvent
+  class StreamEvent < Type
     attr_accessor :uuid, :session_id, :event, :parent_tool_use_id
-
-    def initialize(uuid:, session_id:, event:, parent_tool_use_id: nil)
-      @uuid = uuid
-      @session_id = session_id
-      @event = event
-      @parent_tool_use_id = parent_tool_use_id
-    end
   end
 
   # Tool progress message (type: 'tool_progress')
-  class ToolProgressMessage
+  class ToolProgressMessage < Type
     attr_accessor :uuid, :session_id, :tool_use_id, :tool_name, :parent_tool_use_id,
                   :elapsed_time_seconds, :task_id
-
-    def initialize(uuid: nil, session_id: nil, tool_use_id: nil, tool_name: nil,
-                   parent_tool_use_id: nil, elapsed_time_seconds: nil, task_id: nil)
-      @uuid = uuid
-      @session_id = session_id
-      @tool_use_id = tool_use_id
-      @tool_name = tool_name
-      @parent_tool_use_id = parent_tool_use_id
-      @elapsed_time_seconds = elapsed_time_seconds
-      @task_id = task_id
-    end
   end
 
   # Auth status message (type: 'auth_status')
-  class AuthStatusMessage
+  class AuthStatusMessage < Type
     attr_accessor :uuid, :session_id, :is_authenticating, :output, :error
-
-    def initialize(uuid: nil, session_id: nil, is_authenticating: nil, output: nil, error: nil)
-      @uuid = uuid
-      @session_id = session_id
-      @is_authenticating = is_authenticating
-      @output = output
-      @error = error
-    end
   end
 
   # Tool use summary message (type: 'tool_use_summary')
-  class ToolUseSummaryMessage
+  class ToolUseSummaryMessage < Type
     attr_accessor :uuid, :session_id, :summary, :preceding_tool_use_ids
-
-    def initialize(uuid: nil, session_id: nil, summary: nil, preceding_tool_use_ids: nil)
-      @uuid = uuid
-      @session_id = session_id
-      @summary = summary
-      @preceding_tool_use_ids = preceding_tool_use_ids
-    end
   end
 
   # Prompt suggestion message (type: 'prompt_suggestion')
-  class PromptSuggestionMessage
+  class PromptSuggestionMessage < Type
     attr_accessor :uuid, :session_id, :suggestion
-
-    def initialize(uuid: nil, session_id: nil, suggestion: nil)
-      @uuid = uuid
-      @session_id = session_id
-      @suggestion = suggestion
-    end
   end
 
   # Type constants for rate limit statuses
@@ -564,32 +381,28 @@ module ClaudeAgentSDK
   RATE_LIMIT_TYPES = %w[five_hour seven_day seven_day_opus seven_day_sonnet overage].freeze
 
   # Rate limit info with typed fields
-  class RateLimitInfo
+  class RateLimitInfo < Type
     attr_accessor :status, :resets_at, :rate_limit_type, :utilization,
                   :overage_status, :overage_resets_at, :overage_disabled_reason, :raw
 
-    def initialize(status:, resets_at: nil, rate_limit_type: nil, utilization: nil,
-                   overage_status: nil, overage_resets_at: nil, overage_disabled_reason: nil, raw: {})
-      @status = status
-      @resets_at = resets_at
-      @rate_limit_type = rate_limit_type
-      @utilization = utilization
-      @overage_status = overage_status
-      @overage_resets_at = overage_resets_at
-      @overage_disabled_reason = overage_disabled_reason
-      @raw = raw
+    def initialize(attributes = {})
+      super
+      @raw ||= {}
     end
   end
 
   # Rate limit event emitted when rate limit info changes
-  class RateLimitEvent
-    attr_accessor :rate_limit_info, :uuid, :session_id
+  class RateLimitEvent < Type
+    attr_accessor :uuid, :session_id, :raw_data
+    attr_reader :rate_limit_info
 
-    def initialize(rate_limit_info:, uuid:, session_id:, raw_data: nil)
-      @rate_limit_info = rate_limit_info
-      @uuid = uuid
-      @session_id = session_id
-      @raw_data = raw_data
+    def initialize(attributes = {})
+      super
+      @rate_limit_info ||= RateLimitInfo.new
+    end
+
+    def rate_limit_info=(value)
+      @rate_limit_info = value.is_a?(Hash) ? RateLimitInfo.new(value.merge(raw: value)) : value
     end
 
     # Backward-compatible accessor returning the full raw event payload
@@ -609,12 +422,16 @@ module ClaudeAgentSDK
   THINKING_DISPLAY_VALUES = %w[summarized omitted].freeze
 
   # Adaptive thinking: uses a default budget of 32000 tokens
-  class ThinkingConfigAdaptive
-    attr_accessor :type, :display
+  class ThinkingConfigAdaptive < Type
+    attr_reader :type, :display
 
-    def initialize(display: nil)
+    def initialize(attributes = {})
+      super
       @type = 'adaptive'
-      @display = validate_display(display)
+    end
+
+    def display=(value)
+      @display = validate_display(value)
     end
 
     private
@@ -629,13 +446,17 @@ module ClaudeAgentSDK
   end
 
   # Enabled thinking: uses a user-specified budget
-  class ThinkingConfigEnabled
-    attr_accessor :type, :budget_tokens, :display
+  class ThinkingConfigEnabled < Type
+    attr_accessor :budget_tokens
+    attr_reader :type, :display
 
-    def initialize(budget_tokens:, display: nil)
+    def initialize(attributes = {})
+      super
       @type = 'enabled'
-      @budget_tokens = budget_tokens
-      @display = validate_display(display)
+    end
+
+    def display=(value)
+      @display = validate_display(value)
     end
 
     private
@@ -650,60 +471,29 @@ module ClaudeAgentSDK
   end
 
   # Disabled thinking: sets thinking tokens to 0
-  class ThinkingConfigDisabled
-    attr_accessor :type
+  class ThinkingConfigDisabled < Type
+    attr_reader :type
 
-    def initialize
+    def initialize(attributes = {})
+      super
       @type = 'disabled'
     end
   end
 
   # Agent definition configuration
-  class AgentDefinition
+  class AgentDefinition < Type
     attr_accessor :description, :prompt, :tools, :disallowed_tools, :model, :skills, :memory, :mcp_servers,
                   :initial_prompt, :max_turns, :background, :effort, :permission_mode
-
-    def initialize(description:, prompt:, tools: nil, disallowed_tools: nil, model: nil, skills: nil,
-                   memory: nil, mcp_servers: nil, initial_prompt: nil, max_turns: nil,
-                   background: nil, effort: nil, permission_mode: nil)
-      @description = description
-      @prompt = prompt
-      @tools = tools
-      @disallowed_tools = disallowed_tools # Array of tool names to disallow
-      @model = model
-      @skills = skills # Array of skill names
-      @memory = memory # One of: 'user', 'project', 'local'
-      @mcp_servers = mcp_servers # Array of server names or config hashes
-      @initial_prompt = initial_prompt # Initial prompt sent when agent starts
-      @max_turns = max_turns # Maximum conversation turns for the agent
-      @background = background # Whether this agent runs in background
-      @effort = effort # See ClaudeAgentSDK::EFFORT_LEVELS or an Integer
-      @permission_mode = permission_mode # Permission mode for the agent
-    end
   end
 
   # Permission rule value
-  class PermissionRuleValue
+  class PermissionRuleValue < Type
     attr_accessor :tool_name, :rule_content
-
-    def initialize(tool_name:, rule_content: nil)
-      @tool_name = tool_name
-      @rule_content = rule_content
-    end
   end
 
   # Permission update configuration
-  class PermissionUpdate
+  class PermissionUpdate < Type
     attr_accessor :type, :rules, :behavior, :mode, :directories, :destination
-
-    def initialize(type:, rules: nil, behavior: nil, mode: nil, directories: nil, destination: nil)
-      @type = type
-      @rules = rules
-      @behavior = behavior
-      @mode = mode
-      @directories = directories
-      @destination = destination
-    end
 
     def to_h
       result = { type: @type }
@@ -731,452 +521,342 @@ module ClaudeAgentSDK
   end
 
   # Tool permission context
-  class ToolPermissionContext
+  class ToolPermissionContext < Type
     attr_accessor :signal, :suggestions, :tool_use_id, :agent_id
 
-    def initialize(signal: nil, suggestions: [], tool_use_id: nil, agent_id: nil)
-      @signal = signal
-      @suggestions = suggestions
-      @tool_use_id = tool_use_id # Unique ID for this tool call within the assistant message
-      @agent_id = agent_id # Sub-agent ID if running within an agent context
+    def initialize(attributes = {})
+      super
+      @suggestions ||= []
     end
   end
 
   # Permission results
-  class PermissionResultAllow
-    attr_accessor :behavior, :updated_input, :updated_permissions
+  class PermissionResultAllow < Type
+    attr_accessor :updated_input, :updated_permissions
+    attr_reader :behavior
 
-    def initialize(updated_input: nil, updated_permissions: nil)
+    def initialize(attributes = {})
+      super
       @behavior = 'allow'
-      @updated_input = updated_input
-      @updated_permissions = updated_permissions
     end
   end
 
-  class PermissionResultDeny
-    attr_accessor :behavior, :message, :interrupt
+  class PermissionResultDeny < Type
+    attr_accessor :message, :interrupt
+    attr_reader :behavior
 
-    def initialize(message: '', interrupt: false)
+    def initialize(attributes = {})
+      super
       @behavior = 'deny'
-      @message = message
-      @interrupt = interrupt
+      @message ||= ''
+      @interrupt = false if @interrupt.nil?
     end
   end
 
   # Hook matcher configuration
-  class HookMatcher
+  class HookMatcher < Type
     attr_accessor :matcher, :hooks, :timeout
 
-    def initialize(matcher: nil, hooks: [], timeout: nil)
-      @matcher = matcher
-      @hooks = hooks
-      @timeout = timeout # Timeout in seconds for hook execution
+    def initialize(attributes = {})
+      super
+      @hooks ||= []
     end
   end
 
   # Hook context passed to hook callbacks
-  class HookContext
+  class HookContext < Type
     attr_accessor :signal
-
-    def initialize(signal: nil)
-      @signal = signal
-    end
   end
 
   # Base hook input with common fields
-  class BaseHookInput
+  class BaseHookInput < Type
     attr_accessor :session_id, :transcript_path, :cwd, :permission_mode
-
-    def initialize(session_id: nil, transcript_path: nil, cwd: nil, permission_mode: nil)
-      @session_id = session_id
-      @transcript_path = transcript_path
-      @cwd = cwd
-      @permission_mode = permission_mode
-    end
+    attr_reader :hook_event_name
   end
 
   # PreToolUse hook input
   class PreToolUseHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :tool_name, :tool_input, :tool_use_id, :agent_id, :agent_type
+    attr_accessor :tool_name, :tool_input, :tool_use_id, :agent_id, :agent_type
 
-    def initialize(hook_event_name: 'PreToolUse', tool_name: nil, tool_input: nil, tool_use_id: nil,
-                   agent_id: nil, agent_type: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @tool_name = tool_name
-      @tool_input = tool_input
-      @tool_use_id = tool_use_id
-      @agent_id = agent_id
-      @agent_type = agent_type
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'PreToolUse'
     end
   end
 
   # PostToolUse hook input
   class PostToolUseHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :tool_name, :tool_input, :tool_response, :tool_use_id, :agent_id, :agent_type
+    attr_accessor :tool_name, :tool_input, :tool_response, :tool_use_id, :agent_id, :agent_type
 
-    def initialize(hook_event_name: 'PostToolUse', tool_name: nil, tool_input: nil, tool_response: nil,
-                   tool_use_id: nil, agent_id: nil, agent_type: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @tool_name = tool_name
-      @tool_input = tool_input
-      @tool_response = tool_response
-      @tool_use_id = tool_use_id
-      @agent_id = agent_id
-      @agent_type = agent_type
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'PostToolUse'
     end
   end
 
   # UserPromptSubmit hook input
   class UserPromptSubmitHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :prompt
+    attr_accessor :prompt
 
-    def initialize(hook_event_name: 'UserPromptSubmit', prompt: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @prompt = prompt
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'UserPromptSubmit'
     end
   end
 
   # Stop hook input
   class StopHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :stop_hook_active, :last_assistant_message
+    attr_accessor :stop_hook_active, :last_assistant_message
 
-    def initialize(hook_event_name: 'Stop', stop_hook_active: false, last_assistant_message: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @stop_hook_active = stop_hook_active
-      @last_assistant_message = last_assistant_message
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'Stop'
+      @stop_hook_active = false if @stop_hook_active.nil?
     end
   end
 
   # SubagentStop hook input
   class SubagentStopHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :stop_hook_active, :agent_id, :agent_transcript_path, :agent_type,
+    attr_accessor :stop_hook_active, :agent_id, :agent_transcript_path, :agent_type,
                   :last_assistant_message
 
-    def initialize(hook_event_name: 'SubagentStop', stop_hook_active: false, agent_id: nil,
-                   agent_transcript_path: nil, agent_type: nil, last_assistant_message: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @stop_hook_active = stop_hook_active
-      @agent_id = agent_id
-      @agent_transcript_path = agent_transcript_path
-      @agent_type = agent_type
-      @last_assistant_message = last_assistant_message
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'SubagentStop'
+      @stop_hook_active = false if @stop_hook_active.nil?
     end
   end
 
   # PostToolUseFailure hook input
   class PostToolUseFailureHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :tool_name, :tool_input, :tool_use_id, :error, :is_interrupt,
+    attr_accessor :tool_name, :tool_input, :tool_use_id, :error, :is_interrupt,
                   :agent_id, :agent_type
 
-    def initialize(hook_event_name: 'PostToolUseFailure', tool_name: nil, tool_input: nil, tool_use_id: nil,
-                   error: nil, is_interrupt: nil, agent_id: nil, agent_type: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @tool_name = tool_name
-      @tool_input = tool_input
-      @tool_use_id = tool_use_id
-      @error = error
-      @is_interrupt = is_interrupt
-      @agent_id = agent_id
-      @agent_type = agent_type
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'PostToolUseFailure'
     end
   end
 
   # Notification hook input
   class NotificationHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :message, :title, :notification_type
+    attr_accessor :message, :title, :notification_type
 
-    def initialize(hook_event_name: 'Notification', message: nil, title: nil, notification_type: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @message = message
-      @title = title
-      @notification_type = notification_type
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'Notification'
     end
   end
 
   # SubagentStart hook input
   class SubagentStartHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :agent_id, :agent_type
+    attr_accessor :agent_id, :agent_type
 
-    def initialize(hook_event_name: 'SubagentStart', agent_id: nil, agent_type: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @agent_id = agent_id
-      @agent_type = agent_type
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'SubagentStart'
     end
   end
 
   # PermissionRequest hook input
   class PermissionRequestHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :tool_name, :tool_input, :permission_suggestions, :agent_id, :agent_type
+    attr_accessor :tool_name, :tool_input, :permission_suggestions, :agent_id, :agent_type
 
-    def initialize(hook_event_name: 'PermissionRequest', tool_name: nil, tool_input: nil, permission_suggestions: nil,
-                   agent_id: nil, agent_type: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @tool_name = tool_name
-      @tool_input = tool_input
-      @permission_suggestions = permission_suggestions
-      @agent_id = agent_id
-      @agent_type = agent_type
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'PermissionRequest'
     end
   end
 
   # PreCompact hook input
   class PreCompactHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :trigger, :custom_instructions
+    attr_accessor :trigger, :custom_instructions
 
-    def initialize(hook_event_name: 'PreCompact', trigger: nil, custom_instructions: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @trigger = trigger
-      @custom_instructions = custom_instructions
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'PreCompact'
     end
   end
 
   # SessionStart hook input
   class SessionStartHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :source, :agent_type, :model
+    attr_accessor :source, :agent_type, :model
 
-    def initialize(hook_event_name: 'SessionStart', source: nil, agent_type: nil, model: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @source = source # "startup", "resume", "clear", "compact"
-      @agent_type = agent_type
-      @model = model
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'SessionStart'
     end
   end
 
   # SessionEnd hook input
   class SessionEndHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :reason
+    attr_accessor :reason
 
-    def initialize(hook_event_name: 'SessionEnd', reason: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @reason = reason
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'SessionEnd'
     end
   end
 
   # Setup hook input
   class SetupHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :trigger
+    attr_accessor :trigger
 
-    def initialize(hook_event_name: 'Setup', trigger: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @trigger = trigger # "init" or "maintenance"
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'Setup'
     end
   end
 
   # TeammateIdle hook input
   class TeammateIdleHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :teammate_name, :team_name
+    attr_accessor :teammate_name, :team_name
 
-    def initialize(hook_event_name: 'TeammateIdle', teammate_name: nil, team_name: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @teammate_name = teammate_name
-      @team_name = team_name
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'TeammateIdle'
     end
   end
 
   # TaskCompleted hook input
   class TaskCompletedHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :task_id, :task_subject, :task_description, :teammate_name, :team_name
+    attr_accessor :task_id, :task_subject, :task_description, :teammate_name, :team_name
 
-    def initialize(hook_event_name: 'TaskCompleted', task_id: nil, task_subject: nil, task_description: nil,
-                   teammate_name: nil, team_name: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @task_id = task_id
-      @task_subject = task_subject
-      @task_description = task_description
-      @teammate_name = teammate_name
-      @team_name = team_name
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'TaskCompleted'
     end
   end
 
   # ConfigChange hook input
   class ConfigChangeHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :source, :file_path
+    attr_accessor :source, :file_path
 
-    def initialize(hook_event_name: 'ConfigChange', source: nil, file_path: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @source = source # "user_settings", "project_settings", "local_settings", "policy_settings", "skills"
-      @file_path = file_path
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'ConfigChange'
     end
   end
 
   # WorktreeCreate hook input
   class WorktreeCreateHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :name
+    attr_accessor :name
 
-    def initialize(hook_event_name: 'WorktreeCreate', name: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @name = name
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'WorktreeCreate'
     end
   end
 
   # WorktreeRemove hook input
   class WorktreeRemoveHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :worktree_path
+    attr_accessor :worktree_path
 
-    def initialize(hook_event_name: 'WorktreeRemove', worktree_path: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @worktree_path = worktree_path
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'WorktreeRemove'
     end
   end
 
   # StopFailure hook input
   class StopFailureHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :error, :error_details, :last_assistant_message
+    attr_accessor :error, :error_details, :last_assistant_message
 
-    def initialize(hook_event_name: 'StopFailure', error: nil, error_details: nil,
-                   last_assistant_message: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @error = error
-      @error_details = error_details
-      @last_assistant_message = last_assistant_message
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'StopFailure'
     end
   end
 
   # PostCompact hook input
   class PostCompactHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :trigger, :compact_summary
+    attr_accessor :trigger, :compact_summary
 
-    def initialize(hook_event_name: 'PostCompact', trigger: nil, compact_summary: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @trigger = trigger # "manual" or "auto"
-      @compact_summary = compact_summary
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'PostCompact'
     end
   end
 
   # PermissionDenied hook input
   class PermissionDeniedHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :tool_name, :tool_input, :tool_use_id, :reason, :agent_id, :agent_type
+    attr_accessor :tool_name, :tool_input, :tool_use_id, :reason, :agent_id, :agent_type
 
-    def initialize(hook_event_name: 'PermissionDenied', tool_name: nil, tool_input: nil, tool_use_id: nil,
-                   reason: nil, agent_id: nil, agent_type: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @tool_name = tool_name
-      @tool_input = tool_input
-      @tool_use_id = tool_use_id
-      @reason = reason
-      @agent_id = agent_id
-      @agent_type = agent_type
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'PermissionDenied'
     end
   end
 
   # TaskCreated hook input
   class TaskCreatedHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :task_id, :task_subject, :task_description, :teammate_name, :team_name
+    attr_accessor :task_id, :task_subject, :task_description, :teammate_name, :team_name
 
-    def initialize(hook_event_name: 'TaskCreated', task_id: nil, task_subject: nil, task_description: nil,
-                   teammate_name: nil, team_name: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @task_id = task_id
-      @task_subject = task_subject
-      @task_description = task_description
-      @teammate_name = teammate_name
-      @team_name = team_name
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'TaskCreated'
     end
   end
 
   # Elicitation hook input
   class ElicitationHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :mcp_server_name, :message, :mode, :url,
+    attr_accessor :mcp_server_name, :message, :mode, :url,
                   :elicitation_id, :requested_schema
 
-    def initialize(hook_event_name: 'Elicitation', mcp_server_name: nil, message: nil, mode: nil,
-                   url: nil, elicitation_id: nil, requested_schema: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @mcp_server_name = mcp_server_name
-      @message = message
-      @mode = mode
-      @url = url
-      @elicitation_id = elicitation_id
-      @requested_schema = requested_schema
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'Elicitation'
     end
   end
 
   # ElicitationResult hook input
   class ElicitationResultHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :mcp_server_name, :elicitation_id, :mode, :action, :content
+    attr_accessor :mcp_server_name, :elicitation_id, :mode, :action, :content
 
-    def initialize(hook_event_name: 'ElicitationResult', mcp_server_name: nil, elicitation_id: nil,
-                   mode: nil, action: nil, content: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @mcp_server_name = mcp_server_name
-      @elicitation_id = elicitation_id
-      @mode = mode
-      @action = action
-      @content = content
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'ElicitationResult'
     end
   end
 
   # InstructionsLoaded hook input
   class InstructionsLoadedHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :file_path, :memory_type, :load_reason, :globs, :trigger_file_path
+    attr_accessor :file_path, :memory_type, :load_reason, :globs, :trigger_file_path
 
-    def initialize(hook_event_name: 'InstructionsLoaded', file_path: nil, memory_type: nil,
-                   load_reason: nil, globs: nil, trigger_file_path: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @file_path = file_path
-      @memory_type = memory_type
-      @load_reason = load_reason
-      @globs = globs
-      @trigger_file_path = trigger_file_path
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'InstructionsLoaded'
     end
   end
 
   # CwdChanged hook input
   class CwdChangedHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :old_cwd, :new_cwd
+    attr_accessor :old_cwd, :new_cwd
 
-    def initialize(hook_event_name: 'CwdChanged', old_cwd: nil, new_cwd: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @old_cwd = old_cwd
-      @new_cwd = new_cwd
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'CwdChanged'
     end
   end
 
   # FileChanged hook input
   class FileChangedHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :file_path, :event
+    attr_accessor :file_path, :event
 
-    def initialize(hook_event_name: 'FileChanged', file_path: nil, event: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @file_path = file_path
-      @event = event # "change", "add", or "unlink"
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'FileChanged'
     end
   end
 
   # Setup hook specific output
-  class SetupHookSpecificOutput
-    attr_accessor :hook_event_name, :additional_context
+  class SetupHookSpecificOutput < Type
+    attr_accessor :additional_context
+    attr_reader :hook_event_name
 
-    def initialize(additional_context: nil)
+    def initialize(attributes = {})
+      super
       @hook_event_name = 'Setup'
-      @additional_context = additional_context
     end
 
     def to_h
@@ -1187,17 +867,14 @@ module ClaudeAgentSDK
   end
 
   # PreToolUse hook specific output
-  class PreToolUseHookSpecificOutput
-    attr_accessor :hook_event_name, :permission_decision, :permission_decision_reason,
+  class PreToolUseHookSpecificOutput < Type
+    attr_accessor :permission_decision, :permission_decision_reason,
                   :updated_input, :additional_context
+    attr_reader :hook_event_name
 
-    def initialize(permission_decision: nil, permission_decision_reason: nil, updated_input: nil,
-                   additional_context: nil)
+    def initialize(attributes = {})
+      super
       @hook_event_name = 'PreToolUse'
-      @permission_decision = permission_decision # 'allow', 'deny', or 'ask'
-      @permission_decision_reason = permission_decision_reason
-      @updated_input = updated_input
-      @additional_context = additional_context
     end
 
     def to_h
@@ -1211,13 +888,13 @@ module ClaudeAgentSDK
   end
 
   # PostToolUse hook specific output
-  class PostToolUseHookSpecificOutput
-    attr_accessor :hook_event_name, :additional_context, :updated_mcp_tool_output
+  class PostToolUseHookSpecificOutput < Type
+    attr_accessor :additional_context, :updated_mcp_tool_output
+    attr_reader :hook_event_name
 
-    def initialize(additional_context: nil, updated_mcp_tool_output: nil)
+    def initialize(attributes = {})
+      super
       @hook_event_name = 'PostToolUse'
-      @additional_context = additional_context
-      @updated_mcp_tool_output = updated_mcp_tool_output
     end
 
     def to_h
@@ -1229,12 +906,13 @@ module ClaudeAgentSDK
   end
 
   # PostToolUseFailure hook specific output
-  class PostToolUseFailureHookSpecificOutput
-    attr_accessor :hook_event_name, :additional_context
+  class PostToolUseFailureHookSpecificOutput < Type
+    attr_accessor :additional_context
+    attr_reader :hook_event_name
 
-    def initialize(additional_context: nil)
+    def initialize(attributes = {})
+      super
       @hook_event_name = 'PostToolUseFailure'
-      @additional_context = additional_context
     end
 
     def to_h
@@ -1245,12 +923,13 @@ module ClaudeAgentSDK
   end
 
   # UserPromptSubmit hook specific output
-  class UserPromptSubmitHookSpecificOutput
-    attr_accessor :hook_event_name, :additional_context
+  class UserPromptSubmitHookSpecificOutput < Type
+    attr_accessor :additional_context
+    attr_reader :hook_event_name
 
-    def initialize(additional_context: nil)
+    def initialize(attributes = {})
+      super
       @hook_event_name = 'UserPromptSubmit'
-      @additional_context = additional_context
     end
 
     def to_h
@@ -1261,12 +940,13 @@ module ClaudeAgentSDK
   end
 
   # Notification hook specific output
-  class NotificationHookSpecificOutput
-    attr_accessor :hook_event_name, :additional_context
+  class NotificationHookSpecificOutput < Type
+    attr_accessor :additional_context
+    attr_reader :hook_event_name
 
-    def initialize(additional_context: nil)
+    def initialize(attributes = {})
+      super
       @hook_event_name = 'Notification'
-      @additional_context = additional_context
     end
 
     def to_h
@@ -1277,12 +957,13 @@ module ClaudeAgentSDK
   end
 
   # SubagentStart hook specific output
-  class SubagentStartHookSpecificOutput
-    attr_accessor :hook_event_name, :additional_context
+  class SubagentStartHookSpecificOutput < Type
+    attr_accessor :additional_context
+    attr_reader :hook_event_name
 
-    def initialize(additional_context: nil)
+    def initialize(attributes = {})
+      super
       @hook_event_name = 'SubagentStart'
-      @additional_context = additional_context
     end
 
     def to_h
@@ -1293,12 +974,13 @@ module ClaudeAgentSDK
   end
 
   # PermissionRequest hook specific output
-  class PermissionRequestHookSpecificOutput
-    attr_accessor :hook_event_name, :decision
+  class PermissionRequestHookSpecificOutput < Type
+    attr_accessor :decision
+    attr_reader :hook_event_name
 
-    def initialize(decision: nil)
+    def initialize(attributes = {})
+      super
       @hook_event_name = 'PermissionRequest'
-      @decision = decision
     end
 
     def to_h
@@ -1309,12 +991,13 @@ module ClaudeAgentSDK
   end
 
   # SessionStart hook specific output
-  class SessionStartHookSpecificOutput
-    attr_accessor :hook_event_name, :additional_context
+  class SessionStartHookSpecificOutput < Type
+    attr_accessor :additional_context
+    attr_reader :hook_event_name
 
-    def initialize(additional_context: nil)
+    def initialize(attributes = {})
+      super
       @hook_event_name = 'SessionStart'
-      @additional_context = additional_context
     end
 
     def to_h
@@ -1325,12 +1008,14 @@ module ClaudeAgentSDK
   end
 
   # PermissionDenied hook specific output
-  class PermissionDeniedHookSpecificOutput
-    attr_accessor :hook_event_name, :retry
+  class PermissionDeniedHookSpecificOutput < Type
+    attr_accessor :retry
+    attr_reader :hook_event_name
 
-    def initialize(retry_: false)
+    def initialize(attributes = {})
+      super
       @hook_event_name = 'PermissionDenied'
-      @retry = retry_
+      @retry = false if @retry.nil?
     end
 
     def to_h
@@ -1341,12 +1026,13 @@ module ClaudeAgentSDK
   end
 
   # CwdChanged hook specific output
-  class CwdChangedHookSpecificOutput
-    attr_accessor :hook_event_name, :watch_paths
+  class CwdChangedHookSpecificOutput < Type
+    attr_accessor :watch_paths
+    attr_reader :hook_event_name
 
-    def initialize(watch_paths: nil)
+    def initialize(attributes = {})
+      super
       @hook_event_name = 'CwdChanged'
-      @watch_paths = watch_paths
     end
 
     def to_h
@@ -1357,12 +1043,13 @@ module ClaudeAgentSDK
   end
 
   # FileChanged hook specific output
-  class FileChangedHookSpecificOutput
-    attr_accessor :hook_event_name, :watch_paths
+  class FileChangedHookSpecificOutput < Type
+    attr_accessor :watch_paths
+    attr_reader :hook_event_name
 
-    def initialize(watch_paths: nil)
+    def initialize(attributes = {})
+      super
       @hook_event_name = 'FileChanged'
-      @watch_paths = watch_paths
     end
 
     def to_h
@@ -1373,12 +1060,12 @@ module ClaudeAgentSDK
   end
 
   # Async hook JSON output
-  class AsyncHookJSONOutput
+  class AsyncHookJSONOutput < Type
     attr_accessor :async, :async_timeout
 
-    def initialize(async: true, async_timeout: nil)
-      @async = async
-      @async_timeout = async_timeout
+    def initialize(attributes = {})
+      super
+      @async = true if @async.nil?
     end
 
     def to_h
@@ -1389,19 +1076,14 @@ module ClaudeAgentSDK
   end
 
   # Sync hook JSON output
-  class SyncHookJSONOutput
+  class SyncHookJSONOutput < Type
     attr_accessor :continue, :suppress_output, :stop_reason, :decision,
                   :system_message, :reason, :hook_specific_output
 
-    def initialize(continue: true, suppress_output: false, stop_reason: nil, decision: nil,
-                   system_message: nil, reason: nil, hook_specific_output: nil)
-      @continue = continue
-      @suppress_output = suppress_output
-      @stop_reason = stop_reason
-      @decision = decision
-      @system_message = system_message
-      @reason = reason
-      @hook_specific_output = hook_specific_output
+    def initialize(attributes = {})
+      super
+      @continue = true if @continue.nil?
+      @suppress_output = false if @suppress_output.nil?
     end
 
     def to_h
@@ -1422,63 +1104,44 @@ module ClaudeAgentSDK
   MCP_SERVER_CONNECTION_STATUSES = %w[connected failed needs-auth pending disabled].freeze
 
   # MCP server info (name and version)
-  class McpServerInfo
+  class McpServerInfo < Type
     attr_accessor :name, :version
-
-    def initialize(name:, version: nil)
-      @name = name
-      @version = version
-    end
   end
 
   # MCP tool annotation hints
-  class McpToolAnnotations
+  class McpToolAnnotations < Type
     attr_accessor :read_only, :destructive, :open_world
 
-    def initialize(read_only: nil, destructive: nil, open_world: nil)
-      @read_only = read_only
-      @destructive = destructive
-      @open_world = open_world
-    end
-
+    # Backwards-compatible parse; returns nil for nil input.
     def self.parse(data)
-      return nil unless data
-
-      new(
-        read_only: data.key?(:readOnly) ? data[:readOnly] : data[:read_only],
-        destructive: data[:destructive],
-        open_world: data.key?(:openWorld) ? data[:openWorld] : data[:open_world]
-      )
+      from_hash(data)
     end
   end
 
   # MCP tool info (name, description, annotations)
-  class McpToolInfo
-    attr_accessor :name, :description, :annotations
+  class McpToolInfo < Type
+    attr_accessor :name, :description
+    attr_reader :annotations
 
-    def initialize(name:, description: nil, annotations: nil)
-      @name = name
-      @description = description
-      @annotations = annotations
+    def annotations=(value)
+      @annotations = value.is_a?(Hash) ? McpToolAnnotations.new(value) : value
     end
 
+    # Backwards-compatible parse; returns nil for nil input.
     def self.parse(data)
-      new(
-        name: data[:name],
-        description: data[:description],
-        annotations: McpToolAnnotations.parse(data[:annotations])
-      )
+      from_hash(data)
     end
   end
 
   # Output-only serializable version of McpSdkServerConfig (without live instance)
   # Returned in MCP status responses
-  class McpSdkServerConfigStatus
-    attr_accessor :type, :name
+  class McpSdkServerConfigStatus < Type
+    attr_accessor :name
+    attr_reader :type
 
-    def initialize(type: 'sdk', name:)
-      @type = type
-      @name = name
+    def initialize(attributes = {})
+      super
+      @type = 'sdk'
     end
 
     def to_h
@@ -1488,13 +1151,13 @@ module ClaudeAgentSDK
 
   # Claude.ai proxy MCP server config
   # Output-only type that appears in status responses for servers proxied through Claude.ai
-  class McpClaudeAIProxyServerConfig
-    attr_accessor :type, :url, :id
+  class McpClaudeAIProxyServerConfig < Type
+    attr_accessor :url, :id
+    attr_reader :type
 
-    def initialize(type: 'claudeai-proxy', url:, id:)
-      @type = type
-      @url = url
-      @id = id
+    def initialize(attributes = {})
+      super
+      @type = 'claudeai-proxy'
     end
 
     def to_h
@@ -1503,37 +1166,30 @@ module ClaudeAgentSDK
   end
 
   # Status of a single MCP server connection
-  class McpServerStatus
-    attr_accessor :name, :status, :server_info, :error, :config, :scope, :tools
+  class McpServerStatus < Type
+    attr_accessor :name, :status, :error, :scope
+    attr_reader :server_info, :config, :tools
 
-    def initialize(name:, status:, server_info: nil, error: nil, config: nil, scope: nil, tools: nil)
-      @name = name
-      @status = status
-      @server_info = server_info
-      @error = error
-      @config = config
-      @scope = scope
-      @tools = tools
+    def server_info=(value)
+      @server_info = value.is_a?(Hash) ? McpServerInfo.new(value) : value
     end
 
-    def self.parse(data)
-      server_info = (McpServerInfo.new(name: data[:serverInfo][:name], version: data[:serverInfo][:version]) if data[:serverInfo])
-      tools = data[:tools]&.map { |t| McpToolInfo.parse(t) }
-      config = parse_config(data[:config])
+    def tools=(value)
+      @tools = value.is_a?(Array) ? value.map { |t| t.is_a?(Hash) ? McpToolInfo.new(t) : t } : value
+    end
 
-      new(
-        name: data[:name],
-        status: data[:status],
-        server_info: server_info,
-        error: data[:error],
-        config: config,
-        scope: data[:scope],
-        tools: tools
-      )
+    def config=(value)
+      @config = self.class.parse_config(value) || value
+    end
+
+    # Backwards-compatible parse; normalizes camelCase `serverInfo` and
+    # polymorphically builds the nested `config`.
+    def self.parse(data)
+      from_hash(data)
     end
 
     def self.parse_config(config)
-      return config unless config.is_a?(Hash) && config[:type]
+      return nil unless config.is_a?(Hash) && config[:type]
 
       case config[:type]
       when 'claudeai-proxy'
@@ -1547,28 +1203,27 @@ module ClaudeAgentSDK
   end
 
   # Response from get_mcp_status containing all server statuses
-  class McpStatusResponse
-    attr_accessor :mcp_servers
+  class McpStatusResponse < Type
+    attr_reader :mcp_servers
 
-    def initialize(mcp_servers:)
-      @mcp_servers = mcp_servers
+    def mcp_servers=(value)
+      @mcp_servers = value.is_a?(Array) ? value.map { |s| s.is_a?(Hash) ? McpServerStatus.new(s) : s } : value
     end
 
+    # Backwards-compatible parse; returns nil for nil input.
     def self.parse(data)
-      servers = (data[:mcpServers] || []).map { |s| McpServerStatus.parse(s) }
-      new(mcp_servers: servers)
+      from_hash(data)
     end
   end
 
   # MCP Server configurations
-  class McpStdioServerConfig
-    attr_accessor :type, :command, :args, :env
+  class McpStdioServerConfig < Type
+    attr_accessor :command, :args, :env
+    attr_reader :type
 
-    def initialize(command:, args: nil, env: nil, type: 'stdio')
-      @type = type
-      @command = command
-      @args = args
-      @env = env
+    def initialize(attributes = {})
+      super
+      @type = 'stdio'
     end
 
     def to_h
@@ -1579,13 +1234,13 @@ module ClaudeAgentSDK
     end
   end
 
-  class McpSSEServerConfig
-    attr_accessor :type, :url, :headers
+  class McpSSEServerConfig < Type
+    attr_accessor :url, :headers
+    attr_reader :type
 
-    def initialize(url:, headers: nil)
+    def initialize(attributes = {})
+      super
       @type = 'sse'
-      @url = url
-      @headers = headers
     end
 
     def to_h
@@ -1595,13 +1250,13 @@ module ClaudeAgentSDK
     end
   end
 
-  class McpHttpServerConfig
-    attr_accessor :type, :url, :headers
+  class McpHttpServerConfig < Type
+    attr_accessor :url, :headers
+    attr_reader :type
 
-    def initialize(url:, headers: nil)
+    def initialize(attributes = {})
+      super
       @type = 'http'
-      @url = url
-      @headers = headers
     end
 
     def to_h
@@ -1611,13 +1266,13 @@ module ClaudeAgentSDK
     end
   end
 
-  class McpSdkServerConfig
-    attr_accessor :type, :name, :instance
+  class McpSdkServerConfig < Type
+    attr_accessor :name, :instance
+    attr_reader :type
 
-    def initialize(name:, instance:)
+    def initialize(attributes = {})
+      super
       @type = 'sdk'
-      @name = name
-      @instance = instance
     end
 
     def to_h
@@ -1626,14 +1281,13 @@ module ClaudeAgentSDK
   end
 
   # SDK Plugin configuration
-  class SdkPluginConfig
-    attr_accessor :type, :path
+  class SdkPluginConfig < Type
+    attr_accessor :path
+    attr_reader :type
 
-    def initialize(path:, type: 'local')
-      raise ArgumentError, "unsupported plugin type: #{type}" unless %w[local plugin].include?(type)
-
+    def initialize(attributes = {})
+      super
       @type = 'local'
-      @path = path
     end
 
     def to_h
@@ -1642,28 +1296,10 @@ module ClaudeAgentSDK
   end
 
   # Sandbox network configuration
-  class SandboxNetworkConfig
+  class SandboxNetworkConfig < Type
     attr_accessor :allowed_domains, :allow_managed_domains_only,
                   :allow_unix_sockets, :allow_all_unix_sockets, :allow_local_binding,
                   :http_proxy_port, :socks_proxy_port
-
-    def initialize(
-      allowed_domains: nil,
-      allow_managed_domains_only: nil,
-      allow_unix_sockets: nil,
-      allow_all_unix_sockets: nil,
-      allow_local_binding: nil,
-      http_proxy_port: nil,
-      socks_proxy_port: nil
-    )
-      @allowed_domains = allowed_domains # Array of domain strings
-      @allow_managed_domains_only = allow_managed_domains_only
-      @allow_unix_sockets = allow_unix_sockets # macOS only: Array of socket paths
-      @allow_all_unix_sockets = allow_all_unix_sockets
-      @allow_local_binding = allow_local_binding
-      @http_proxy_port = http_proxy_port
-      @socks_proxy_port = socks_proxy_port
-    end
 
     def to_h
       result = {}
@@ -1679,17 +1315,8 @@ module ClaudeAgentSDK
   end
 
   # Sandbox filesystem configuration
-  class SandboxFilesystemConfig
+  class SandboxFilesystemConfig < Type
     attr_accessor :allow_write, :deny_write, :deny_read, :allow_read, :allow_managed_read_paths_only
-
-    def initialize(allow_write: nil, deny_write: nil, deny_read: nil, allow_read: nil,
-                   allow_managed_read_paths_only: nil)
-      @allow_write = allow_write # Array of paths to allow writing
-      @deny_write = deny_write   # Array of paths to deny writing
-      @deny_read = deny_read     # Array of paths to deny reading
-      @allow_read = allow_read   # Array of paths to re-allow reading within denyRead
-      @allow_managed_read_paths_only = allow_managed_read_paths_only
-    end
 
     def to_h
       result = {}
@@ -1703,37 +1330,11 @@ module ClaudeAgentSDK
   end
 
   # Sandbox settings for isolated command execution
-  class SandboxSettings
+  class SandboxSettings < Type
     attr_accessor :enabled, :fail_if_unavailable, :auto_allow_bash_if_sandboxed,
                   :excluded_commands, :allow_unsandboxed_commands, :network, :filesystem,
                   :ignore_violations, :enable_weaker_nested_sandbox,
                   :enable_weaker_network_isolation, :ripgrep
-
-    def initialize(
-      enabled: nil,
-      fail_if_unavailable: nil,
-      auto_allow_bash_if_sandboxed: nil,
-      excluded_commands: nil,
-      allow_unsandboxed_commands: nil,
-      network: nil,
-      filesystem: nil,
-      ignore_violations: nil,
-      enable_weaker_nested_sandbox: nil,
-      enable_weaker_network_isolation: nil,
-      ripgrep: nil
-    )
-      @enabled = enabled
-      @fail_if_unavailable = fail_if_unavailable
-      @auto_allow_bash_if_sandboxed = auto_allow_bash_if_sandboxed
-      @excluded_commands = excluded_commands # Array of commands to exclude
-      @allow_unsandboxed_commands = allow_unsandboxed_commands
-      @network = network # SandboxNetworkConfig instance
-      @filesystem = filesystem # SandboxFilesystemConfig instance
-      @ignore_violations = ignore_violations # Hash of { category => [patterns] }
-      @enable_weaker_nested_sandbox = enable_weaker_nested_sandbox
-      @enable_weaker_network_isolation = enable_weaker_network_isolation # macOS only
-      @ripgrep = ripgrep # Hash with :command and optional :args
-    end
 
     def to_h
       result = {}
@@ -1753,23 +1354,15 @@ module ClaudeAgentSDK
   end
 
   # Result of a session fork operation
-  class ForkSessionResult
+  class ForkSessionResult < Type
     attr_accessor :session_id
-
-    def initialize(session_id:)
-      @session_id = session_id
-    end
   end
 
   # API-side task budget in tokens.
   # When set, the model is made aware of its remaining token budget so it can
   # pace tool use and wrap up before the limit.
-  class TaskBudget
+  class TaskBudget < Type
     attr_accessor :total
-
-    def initialize(total:)
-      @total = total
-    end
 
     def to_h
       { total: @total }
@@ -1777,12 +1370,13 @@ module ClaudeAgentSDK
   end
 
   # System prompt file configuration — loads system prompt from a file path
-  class SystemPromptFile
-    attr_accessor :type, :path
+  class SystemPromptFile < Type
+    attr_accessor :path
+    attr_reader :type
 
-    def initialize(path:)
+    def initialize(attributes = {})
+      super
       @type = 'file'
-      @path = path
     end
 
     def to_h
@@ -1791,14 +1385,13 @@ module ClaudeAgentSDK
   end
 
   # System prompt preset configuration
-  class SystemPromptPreset
-    attr_accessor :type, :preset, :append, :exclude_dynamic_sections
+  class SystemPromptPreset < Type
+    attr_reader :type
+    attr_accessor :preset, :append, :exclude_dynamic_sections
 
-    def initialize(preset:, append: nil, exclude_dynamic_sections: nil)
+    def initialize(attributes = {})
+      super
       @type = 'preset'
-      @preset = preset
-      @append = append
-      @exclude_dynamic_sections = exclude_dynamic_sections
     end
 
     def to_h
@@ -1810,12 +1403,13 @@ module ClaudeAgentSDK
   end
 
   # Tools preset configuration
-  class ToolsPreset
-    attr_accessor :type, :preset
+  class ToolsPreset < Type
+    attr_reader :type
+    attr_accessor :preset
 
-    def initialize(preset:)
+    def initialize(attributes = {})
+      super
       @type = 'preset'
-      @preset = preset
     end
 
     def to_h
@@ -1824,7 +1418,7 @@ module ClaudeAgentSDK
   end
 
   # Claude Agent Options for configuring queries
-  class ClaudeAgentOptions
+  class ClaudeAgentOptions < Type
     attr_accessor :allowed_tools, :system_prompt, :mcp_servers, :permission_mode,
                   :continue_conversation, :resume, :session_id, :max_turns, :disallowed_tools,
                   :model, :permission_prompt_tool_name, :cwd, :cli_path, :settings,
@@ -1836,52 +1430,84 @@ module ClaudeAgentSDK
                   :betas, :tools, :sandbox, :enable_file_checkpointing, :append_allowed_tools,
                   :thinking, :effort, :bare, :observers, :task_budget
 
-    # Non-nil defaults for options that need them.
-    # Keys absent from here default to nil.
-    OPTION_DEFAULTS = {
-      allowed_tools: [], disallowed_tools: [], add_dirs: [],
-      mcp_servers: {}, env: {}, extra_args: {},
-      continue_conversation: false, include_partial_messages: false,
-      fork_session: false, enable_file_checkpointing: false,
-      observers: []
-    }.freeze
+    def initialize(attributes = {})
+      self.fork_session = false
+      self.continue_conversation = false
+      self.include_partial_messages = false
+      self.enable_file_checkpointing = false
 
-    # Valid option names derived from attr_accessor declarations.
-    VALID_OPTIONS = instance_methods.grep(/=\z/).map { |m| m.to_s.chomp('=').to_sym }.freeze
+      super(merge_with_defaults(attributes || {}))
 
-    # Using **kwargs lets us distinguish "caller passed allowed_tools: []"
-    # from "caller omitted allowed_tools" — critical for correct merge with
-    # configured defaults.
-    def initialize(**kwargs)
-      unknown = kwargs.keys - VALID_OPTIONS
-      raise ArgumentError, "unknown keyword#{'s' if unknown.size > 1}: #{unknown.join(', ')}" if unknown.any?
-
-      merged = merge_with_defaults(kwargs)
-      OPTION_DEFAULTS.merge(merged).each do |key, value|
-        instance_variable_set(:"@#{key}", value)
-      end
+      # Non-nil defaults for options that need them.
+      self.env              ||= {}
+      self.extra_args       ||= {}
+      self.mcp_servers      ||= {}
+      self.add_dirs         ||= []
+      self.observers        ||= []
+      self.allowed_tools    ||= []
+      self.disallowed_tools ||= []
     end
 
     def dup_with(**changes)
       new_options = self.dup
-      changes.each { |key, value| new_options.send(:"#{key}=", value) }
+      changes.each { |key, value| new_options[key] = value }
       new_options
+    end
+
+    def bare?
+      !!bare
+    end
+
+    def bare=(value)
+      @bare = coerce_boolean(value)
+    end
+
+    def fork_session?
+      !!fork_session
+    end
+
+    def fork_session=(value)
+      @fork_session = coerce_boolean(value)
+    end
+
+    def enable_file_checkpointing?
+      !!enable_file_checkpointing
+    end
+
+    def enable_file_checkpointing=(value)
+      @enable_file_checkpointing = coerce_boolean(value)
+    end
+
+    def include_partial_messages?
+      !!include_partial_messages
+    end
+
+    def include_partial_messages=(value)
+      @include_partial_messages = coerce_boolean(value)
+    end
+
+    def continue_conversation?
+      !!continue_conversation
+    end
+
+    def continue_conversation=(value)
+      @continue_conversation = coerce_boolean(value)
     end
 
     private
 
-    # Merge caller-provided kwargs with configured defaults.
+    # Merge caller-provided attributes with configured defaults.
     # Only keys the caller explicitly passed are treated as overrides;
-    # method-signature defaults ([], {}, false) are NOT in kwargs unless the caller wrote them.
-    def merge_with_defaults(kwargs)
-      return OPTION_DEFAULTS.merge(kwargs) unless defined?(ClaudeAgentSDK) && ClaudeAgentSDK.respond_to?(:default_options)
+    # method-signature defaults ([], {}, false) are NOT present unless the caller wrote them.
+    def merge_with_defaults(attributes)
+      return attributes unless defined?(ClaudeAgentSDK) && ClaudeAgentSDK.respond_to?(:default_options)
 
       defaults = ClaudeAgentSDK.default_options
-      return OPTION_DEFAULTS.merge(kwargs) unless defaults.any?
+      return attributes unless defaults.any?
 
       # Start from configured defaults (deep dup hashes to prevent mutation)
       result = defaults.transform_values { |v| v.is_a?(Hash) ? v.dup : v }
-      kwargs.each do |key, value|
+      attributes.each do |key, value|
         default_val = result[key]
         result[key] = if value.nil?
                         default_val # nil means "no preference" — keep the configured default
@@ -1891,46 +1517,22 @@ module ClaudeAgentSDK
                         value
                       end
       end
-      OPTION_DEFAULTS.merge(result)
+      result
     end
   end
 
   # SDK MCP Tool definition
-  class SdkMcpTool
+  class SdkMcpTool < Type
     attr_accessor :name, :description, :input_schema, :handler, :annotations, :meta
-
-    def initialize(name:, description:, input_schema:, handler:, annotations: nil, meta: nil)
-      @name = name
-      @description = description
-      @input_schema = input_schema
-      @handler = handler
-      @annotations = annotations # MCP tool annotations (e.g., { title: '...', readOnlyHint: true })
-      @meta = meta # MCP _meta field (e.g., { 'anthropic/maxResultSizeChars' => 100000 })
-    end
   end
 
   # SDK MCP Resource definition
-  class SdkMcpResource
+  class SdkMcpResource < Type
     attr_accessor :uri, :name, :description, :mime_type, :reader
-
-    def initialize(uri:, name:, description: nil, mime_type: nil, reader:)
-      @uri = uri
-      @name = name
-      @description = description
-      @mime_type = mime_type
-      @reader = reader
-    end
   end
 
   # SDK MCP Prompt definition
-  class SdkMcpPrompt
+  class SdkMcpPrompt < Type
     attr_accessor :name, :description, :arguments, :generator
-
-    def initialize(name:, description: nil, arguments: nil, generator:)
-      @name = name
-      @description = description
-      @arguments = arguments
-      @generator = generator
-    end
   end
 end

--- a/lib/claude_agent_sdk/types.rb
+++ b/lib/claude_agent_sdk/types.rb
@@ -57,80 +57,150 @@ module ClaudeAgentSDK
   # Available beta features that can be enabled via the betas option
   SDK_BETAS = %w[context-1m-2025-08-07].freeze
 
+  # Base class for all types.
+  class Type
+    def self.wrap(object)
+      case object
+      when self
+        object
+      else
+        new(object)
+      end
+    end
+
+    def self.from_hash(hash)
+      return unless hash.is_a?(Hash)
+
+      new(hash)
+    end
+
+    def initialize(attributes = {})
+      assign_attributes(attributes) if attributes
+      super()
+    end
+
+    def [](name)
+      read_attribute(name)
+    end
+
+    def []=(name, value)
+      assign_attribute(name, value)
+    end
+
+    # Subclasses should override this to return a hash representation of the object.
+    def to_h
+      {}
+    end
+
+    private
+
+    # Allow camelCase attribute access
+    def method_missing(method_name, ...)
+      normalized = normalize_name(method_name)
+
+      if normalized != method_name.to_s && respond_to?(normalized)
+        public_send(normalized, ...)
+      else
+        super
+      end
+    end
+
+    def respond_to_missing?(method_name, include_private = false)
+      normalized = normalize_name(method_name)
+      (normalized != method_name.to_s && respond_to?(normalized)) || super
+    end
+
+    def assign_attributes(attributes)
+      raise ArgumentError, "When assigning attributes, you must pass a hash as an argument, #{attributes.inspect} passed." unless attributes.respond_to?(:each_pair)
+
+      return if attributes.empty?
+
+      attributes.each_pair { |name, value| assign_attribute(name, value) }
+    end
+
+    def assign_attribute(name, value)
+      setter = :"#{normalize_name(name)}="
+      public_send(setter, value) if respond_to?(setter)
+    end
+
+    def read_attribute(name)
+      getter = normalize_name(name)
+      public_send(getter) if respond_to?(getter)
+    end
+
+    def normalize_name(name)
+      name = name.dup.to_s
+      name.gsub!(/(?<=[A-Z])(?=[A-Z][a-z])|(?<=[a-z\d])(?=[A-Z])/, "_")
+      name.tr!("-", "_")
+      name.downcase!
+      name
+    end
+
+    FALSE_VALUES = [
+      false, 0,
+      "0", :"0",
+      "f", :f,
+      "F", :F,
+      "false", :false,
+      "FALSE", :FALSE,
+      "off", :off,
+      "OFF", :OFF,
+    ].to_set.freeze
+
+    private_constant :FALSE_VALUES
+
+    def coerce_boolean(value)
+      return if value.nil?
+
+      if value == ""
+        nil
+      else
+        !FALSE_VALUES.include?(value)
+      end
+    end
+  end
+
   # Content Blocks
 
   # Text content block
-  class TextBlock
+  class TextBlock < Type
     attr_accessor :text
-
-    def initialize(text:)
-      @text = text
-    end
   end
 
   # Thinking content block
-  class ThinkingBlock
+  class ThinkingBlock < Type
     attr_accessor :thinking, :signature
-
-    def initialize(thinking:, signature:)
-      @thinking = thinking
-      @signature = signature
-    end
   end
 
   # Tool use content block
-  class ToolUseBlock
+  class ToolUseBlock < Type
     attr_accessor :id, :name, :input
-
-    def initialize(id:, name:, input:)
-      @id = id
-      @name = name
-      @input = input
-    end
   end
 
   # Tool result content block
-  class ToolResultBlock
+  class ToolResultBlock < Type
     attr_accessor :tool_use_id, :content, :is_error
-
-    def initialize(tool_use_id:, content: nil, is_error: nil)
-      @tool_use_id = tool_use_id
-      @content = content
-      @is_error = is_error
-    end
   end
 
   # Generic content block for types the SDK doesn't explicitly handle (e.g., "document", "image").
   # Preserves the raw hash data for forward compatibility with newer CLI versions.
-  class UnknownBlock
+  class UnknownBlock < Type
     attr_accessor :type, :data
-
-    def initialize(type:, data:)
-      @type = type
-      @data = data
-    end
   end
 
   # Message Types
 
   # User message
-  class UserMessage
+  class UserMessage < Type
     attr_accessor :content, :uuid, :parent_tool_use_id, :tool_use_result
-
-    def initialize(content:, uuid: nil, parent_tool_use_id: nil, tool_use_result: nil)
-      @content = content
-      @uuid = uuid # Unique identifier for rewind support
-      @parent_tool_use_id = parent_tool_use_id
-      @tool_use_result = tool_use_result # Tool result data when message is a tool response
-    end
 
     # Concatenated text of this message. Handles both String content
     # (plain-text user prompt) and Array-of-blocks content (typed content).
     # Returns "" when there is no text.
     def text
-      case @content
-      when String then @content
-      when Array then @content.grep(TextBlock).map(&:text).join("\n\n")
+      case content
+      when String then content
+      when Array then content.grep(TextBlock).map(&:text).join("\n\n")
       else ''
       end
     end
@@ -139,39 +209,28 @@ module ClaudeAgentSDK
   end
 
   # Assistant message with content blocks
-  class AssistantMessage
+  class AssistantMessage < Type
     attr_accessor :content, :model, :parent_tool_use_id, :error, :usage,
                   :message_id, :stop_reason, :session_id, :uuid
-
-    def initialize(content:, model:, parent_tool_use_id: nil, error: nil, usage: nil,
-                   message_id: nil, stop_reason: nil, session_id: nil, uuid: nil)
-      @content = content
-      @model = model
-      @parent_tool_use_id = parent_tool_use_id
-      @error = error # One of: authentication_failed, billing_error, rate_limit, invalid_request, server_error, unknown
-      @usage = usage # Token usage info from the API response
-      @message_id = message_id # Unique message identifier from the API (message.id)
-      @stop_reason = stop_reason # Why the assistant stopped (e.g., "end_turn", "max_tokens")
-      @session_id = session_id # Session the message belongs to
-      @uuid = uuid # Unique message UUID in the session transcript
-    end
 
     # Concatenated text across every TextBlock in this message's content.
     # Returns "" when the message has no text (e.g., a pure tool_use turn).
     def text
-      Array(@content).grep(TextBlock).map(&:text).join("\n\n")
+      Array(content).grep(TextBlock).map(&:text).join("\n\n")
     end
 
     alias to_s text
   end
 
-  # System message with metadata
-  class SystemMessage
+  # System message with metadata.
+  # When constructed from a raw CLI hash, the whole hash is stored in `#data`
+  # unless the caller explicitly provides a `:data` entry.
+  class SystemMessage < Type
     attr_accessor :subtype, :data
 
-    def initialize(subtype:, data:)
-      @subtype = subtype
-      @data = data
+    def initialize(attributes = {})
+      super
+      @data ||= attributes if attributes.is_a?(Hash)
     end
   end
 
@@ -180,229 +239,84 @@ module ClaudeAgentSDK
     attr_accessor :uuid, :session_id, :agents, :api_key_source, :betas,
                   :claude_code_version, :cwd, :tools, :mcp_servers, :model,
                   :permission_mode, :slash_commands, :output_style, :skills, :plugins,
-                  :fast_mode_state
-
-    def initialize(subtype:, data:, uuid: nil, session_id: nil, agents: nil,
-                   api_key_source: nil, betas: nil, claude_code_version: nil,
-                   cwd: nil, tools: nil, mcp_servers: nil, model: nil,
-                   permission_mode: nil, slash_commands: nil, output_style: nil,
-                   skills: nil, plugins: nil, fast_mode_state: nil)
-      super(subtype: subtype, data: data)
-      @uuid = uuid
-      @session_id = session_id
-      @agents = agents
-      @api_key_source = api_key_source
-      @betas = betas
-      @claude_code_version = claude_code_version
-      @cwd = cwd
-      @tools = tools
-      @mcp_servers = mcp_servers
-      @model = model
-      @permission_mode = permission_mode
-      @slash_commands = slash_commands
-      @output_style = output_style
-      @skills = skills
-      @plugins = plugins
-      @fast_mode_state = fast_mode_state # "off", "cooldown", or "on"
-    end
+                  :fast_mode_state # "off", "cooldown", or "on"
   end
 
   # Compact boundary system message (emitted after context compaction completes)
   class CompactBoundaryMessage < SystemMessage
-    attr_accessor :uuid, :session_id, :compact_metadata
+    attr_accessor :uuid, :session_id
+    attr_reader :compact_metadata
 
-    def initialize(subtype:, data:, uuid: nil, session_id: nil, compact_metadata: nil)
-      super(subtype: subtype, data: data)
-      @uuid = uuid
-      @session_id = session_id
-      @compact_metadata = compact_metadata
+    def compact_metadata=(value)
+      @compact_metadata = value.is_a?(Hash) ? CompactMetadata.new(value) : value
     end
   end
 
   # Metadata about a compaction event
-  class CompactMetadata
+  class CompactMetadata < Type
     attr_accessor :pre_tokens, :post_tokens, :trigger, :custom_instructions, :preserved_segment
-
-    def initialize(pre_tokens: nil, post_tokens: nil, trigger: nil, custom_instructions: nil, preserved_segment: nil)
-      @pre_tokens = pre_tokens
-      @post_tokens = post_tokens
-      @trigger = trigger # "manual" or "auto"
-      @custom_instructions = custom_instructions
-      @preserved_segment = preserved_segment # Hash with head_uuid, anchor_uuid, tail_uuid
-    end
-
-    def self.from_hash(hash)
-      return nil unless hash.is_a?(Hash)
-
-      preserved = hash[:preserved_segment] || hash['preserved_segment'] ||
-                  hash[:preservedSegment] || hash['preservedSegment']
-
-      new(
-        pre_tokens: hash[:pre_tokens] || hash['pre_tokens'] || hash[:preTokens] || hash['preTokens'],
-        post_tokens: hash[:post_tokens] || hash['post_tokens'] || hash[:postTokens] || hash['postTokens'],
-        trigger: hash[:trigger] || hash['trigger'],
-        custom_instructions: hash[:custom_instructions] || hash['custom_instructions'] ||
-                             hash[:customInstructions] || hash['customInstructions'],
-        preserved_segment: preserved
-      )
-    end
   end
 
   # Status system message (compacting status, permission mode changes)
   class StatusMessage < SystemMessage
     attr_accessor :uuid, :session_id, :status, :permission_mode
-
-    def initialize(subtype:, data:, uuid: nil, session_id: nil, status: nil, permission_mode: nil)
-      super(subtype: subtype, data: data)
-      @uuid = uuid
-      @session_id = session_id
-      @status = status # "compacting" or nil
-      @permission_mode = permission_mode
-    end
   end
 
   # API retry system message
   class APIRetryMessage < SystemMessage
     attr_accessor :uuid, :session_id, :attempt, :max_retries, :retry_delay_ms, :error_status, :error
-
-    def initialize(subtype:, data:, uuid: nil, session_id: nil, attempt: nil, max_retries: nil,
-                   retry_delay_ms: nil, error_status: nil, error: nil)
-      super(subtype: subtype, data: data)
-      @uuid = uuid
-      @session_id = session_id
-      @attempt = attempt
-      @max_retries = max_retries
-      @retry_delay_ms = retry_delay_ms
-      @error_status = error_status
-      @error = error
-    end
   end
 
   # Local command output system message
   class LocalCommandOutputMessage < SystemMessage
     attr_accessor :uuid, :session_id, :content
-
-    def initialize(subtype:, data:, uuid: nil, session_id: nil, content: nil)
-      super(subtype: subtype, data: data)
-      @uuid = uuid
-      @session_id = session_id
-      @content = content
-    end
   end
 
   # Hook started system message
   class HookStartedMessage < SystemMessage
     attr_accessor :uuid, :session_id, :hook_id, :hook_name, :hook_event
-
-    def initialize(subtype:, data:, uuid: nil, session_id: nil, hook_id: nil, hook_name: nil, hook_event: nil)
-      super(subtype: subtype, data: data)
-      @uuid = uuid
-      @session_id = session_id
-      @hook_id = hook_id
-      @hook_name = hook_name
-      @hook_event = hook_event
-    end
   end
 
   # Hook progress system message
   class HookProgressMessage < SystemMessage
     attr_accessor :uuid, :session_id, :hook_id, :hook_name, :hook_event, :stdout, :stderr, :output
-
-    def initialize(subtype:, data:, uuid: nil, session_id: nil, hook_id: nil, hook_name: nil,
-                   hook_event: nil, stdout: nil, stderr: nil, output: nil)
-      super(subtype: subtype, data: data)
-      @uuid = uuid
-      @session_id = session_id
-      @hook_id = hook_id
-      @hook_name = hook_name
-      @hook_event = hook_event
-      @stdout = stdout
-      @stderr = stderr
-      @output = output
-    end
   end
 
   # Hook response system message
   class HookResponseMessage < SystemMessage
     attr_accessor :uuid, :session_id, :hook_id, :hook_name, :hook_event,
-                  :output, :stdout, :stderr, :exit_code, :outcome
-
-    def initialize(subtype:, data:, uuid: nil, session_id: nil, hook_id: nil, hook_name: nil,
-                   hook_event: nil, output: nil, stdout: nil, stderr: nil, exit_code: nil, outcome: nil)
-      super(subtype: subtype, data: data)
-      @uuid = uuid
-      @session_id = session_id
-      @hook_id = hook_id
-      @hook_name = hook_name
-      @hook_event = hook_event
-      @output = output
-      @stdout = stdout
-      @stderr = stderr
-      @exit_code = exit_code
-      @outcome = outcome # "success", "error", or "cancelled"
-    end
+                  :output, :stdout, :stderr, :exit_code,
+                  :outcome # "success", "error", or "cancelled"
   end
 
   # Session state changed system message
   class SessionStateChangedMessage < SystemMessage
-    attr_accessor :uuid, :session_id, :state
-
-    def initialize(subtype:, data:, uuid: nil, session_id: nil, state: nil)
-      super(subtype: subtype, data: data)
-      @uuid = uuid
-      @session_id = session_id
-      @state = state # "idle", "running", or "requires_action"
-    end
+    attr_accessor :uuid, :session_id,
+                  :state # "idle", "running", or "requires_action"
   end
 
   # Files persisted system message
   class FilesPersistedMessage < SystemMessage
     attr_accessor :uuid, :session_id, :files, :failed, :processed_at
-
-    def initialize(subtype:, data:, uuid: nil, session_id: nil, files: nil, failed: nil, processed_at: nil)
-      super(subtype: subtype, data: data)
-      @uuid = uuid
-      @session_id = session_id
-      @files = files # Array of { filename:, file_id: }
-      @failed = failed # Array of { filename:, error: }
-      @processed_at = processed_at
-    end
   end
 
   # Elicitation complete system message
   class ElicitationCompleteMessage < SystemMessage
     attr_accessor :uuid, :session_id, :mcp_server_name, :elicitation_id
-
-    def initialize(subtype:, data:, uuid: nil, session_id: nil, mcp_server_name: nil, elicitation_id: nil)
-      super(subtype: subtype, data: data)
-      @uuid = uuid
-      @session_id = session_id
-      @mcp_server_name = mcp_server_name
-      @elicitation_id = elicitation_id
-    end
   end
 
   # Task lifecycle notification statuses
   TASK_NOTIFICATION_STATUSES = %w[completed failed stopped].freeze
 
   # Typed usage data for task progress and notifications
-  class TaskUsage
+  class TaskUsage < Type
     attr_accessor :total_tokens, :tool_uses, :duration_ms
 
-    def initialize(total_tokens: 0, tool_uses: 0, duration_ms: 0)
-      @total_tokens = total_tokens
-      @tool_uses = tool_uses
-      @duration_ms = duration_ms
-    end
-
-    def self.from_hash(hash)
-      return nil unless hash.is_a?(Hash)
-
-      new(
-        total_tokens: hash[:total_tokens] || hash['total_tokens'] || hash[:totalTokens] || hash['totalTokens'] || 0,
-        tool_uses: hash[:tool_uses] || hash['tool_uses'] || hash[:toolUses] || hash['toolUses'] || 0,
-        duration_ms: hash[:duration_ms] || hash['duration_ms'] || hash[:durationMs] || hash['durationMs'] || 0
-      )
+    def initialize(attributes = {})
+      super
+      @total_tokens ||= 0
+      @tool_uses    ||= 0
+      @duration_ms  ||= 0
     end
   end
 
@@ -410,151 +324,54 @@ module ClaudeAgentSDK
   class TaskStartedMessage < SystemMessage
     attr_accessor :task_id, :description, :uuid, :session_id, :tool_use_id, :task_type,
                   :workflow_name, :prompt
-
-    def initialize(subtype:, data:, task_id:, description:, uuid:, session_id:,
-                   tool_use_id: nil, task_type: nil, workflow_name: nil, prompt: nil)
-      super(subtype: subtype, data: data)
-      @task_id = task_id
-      @description = description
-      @uuid = uuid
-      @session_id = session_id
-      @tool_use_id = tool_use_id
-      @task_type = task_type
-      @workflow_name = workflow_name
-      @prompt = prompt
-    end
   end
 
   # Task progress system message (periodic update from a running task)
   class TaskProgressMessage < SystemMessage
     attr_accessor :task_id, :description, :usage, :uuid, :session_id, :tool_use_id, :last_tool_name, :summary
-
-    def initialize(subtype:, data:, task_id:, description:, usage:, uuid:, session_id:,
-                   tool_use_id: nil, last_tool_name: nil, summary: nil)
-      super(subtype: subtype, data: data)
-      @task_id = task_id
-      @description = description
-      @usage = usage
-      @uuid = uuid
-      @session_id = session_id
-      @tool_use_id = tool_use_id
-      @last_tool_name = last_tool_name
-      @summary = summary
-    end
   end
 
   # Task notification system message (task completed/failed/stopped)
   class TaskNotificationMessage < SystemMessage
     attr_accessor :task_id, :status, :output_file, :summary, :uuid, :session_id, :tool_use_id, :usage
-
-    def initialize(subtype:, data:, task_id:, status:, output_file:, summary:, uuid:, session_id:,
-                   tool_use_id: nil, usage: nil)
-      super(subtype: subtype, data: data)
-      @task_id = task_id
-      @status = status
-      @output_file = output_file
-      @summary = summary
-      @uuid = uuid
-      @session_id = session_id
-      @tool_use_id = tool_use_id
-      @usage = usage
-    end
   end
 
   # Result message with cost and usage information
-  class ResultMessage
+  class ResultMessage < Type
     attr_accessor :subtype, :duration_ms, :duration_api_ms, :is_error,
                   :num_turns, :session_id, :stop_reason, :total_cost_usd, :usage,
-                  :result, :structured_output, :model_usage, :permission_denials, :errors,
-                  :uuid, :fast_mode_state
-
-    def initialize(subtype:, duration_ms:, duration_api_ms:, is_error:,
-                   num_turns:, session_id:, stop_reason: nil, total_cost_usd: nil,
-                   usage: nil, result: nil, structured_output: nil,
-                   model_usage: nil, permission_denials: nil, errors: nil,
-                   uuid: nil, fast_mode_state: nil)
-      @subtype = subtype
-      @duration_ms = duration_ms
-      @duration_api_ms = duration_api_ms
-      @is_error = is_error
-      @num_turns = num_turns
-      @session_id = session_id
-      @stop_reason = stop_reason
-      @total_cost_usd = total_cost_usd
-      @usage = usage
-      @result = result
-      @structured_output = structured_output
-      @model_usage = model_usage # Hash of { model_name => usage_data }
-      @permission_denials = permission_denials # Array of { tool_name:, tool_use_id:, tool_input: }
-      @errors = errors # Array of error strings (present on error subtypes)
-      @uuid = uuid
-      @fast_mode_state = fast_mode_state # "off", "cooldown", or "on"
-    end
+                  :result, :structured_output,
+                  :model_usage,        # Hash of { model_name => usage_data }
+                  :permission_denials, # Array of { tool_name:, tool_use_id:, tool_input: }
+                  :errors,             # Array of error strings (present on error subtypes)
+                  :uuid,
+                  :fast_mode_state     # "off", "cooldown", or "on"
   end
 
   # Stream event for partial message updates
-  class StreamEvent
+  class StreamEvent < Type
     attr_accessor :uuid, :session_id, :event, :parent_tool_use_id
-
-    def initialize(uuid:, session_id:, event:, parent_tool_use_id: nil)
-      @uuid = uuid
-      @session_id = session_id
-      @event = event
-      @parent_tool_use_id = parent_tool_use_id
-    end
   end
 
   # Tool progress message (type: 'tool_progress')
-  class ToolProgressMessage
+  class ToolProgressMessage < Type
     attr_accessor :uuid, :session_id, :tool_use_id, :tool_name, :parent_tool_use_id,
                   :elapsed_time_seconds, :task_id
-
-    def initialize(uuid: nil, session_id: nil, tool_use_id: nil, tool_name: nil,
-                   parent_tool_use_id: nil, elapsed_time_seconds: nil, task_id: nil)
-      @uuid = uuid
-      @session_id = session_id
-      @tool_use_id = tool_use_id
-      @tool_name = tool_name
-      @parent_tool_use_id = parent_tool_use_id
-      @elapsed_time_seconds = elapsed_time_seconds
-      @task_id = task_id
-    end
   end
 
   # Auth status message (type: 'auth_status')
-  class AuthStatusMessage
+  class AuthStatusMessage < Type
     attr_accessor :uuid, :session_id, :is_authenticating, :output, :error
-
-    def initialize(uuid: nil, session_id: nil, is_authenticating: nil, output: nil, error: nil)
-      @uuid = uuid
-      @session_id = session_id
-      @is_authenticating = is_authenticating
-      @output = output
-      @error = error
-    end
   end
 
   # Tool use summary message (type: 'tool_use_summary')
-  class ToolUseSummaryMessage
+  class ToolUseSummaryMessage < Type
     attr_accessor :uuid, :session_id, :summary, :preceding_tool_use_ids
-
-    def initialize(uuid: nil, session_id: nil, summary: nil, preceding_tool_use_ids: nil)
-      @uuid = uuid
-      @session_id = session_id
-      @summary = summary
-      @preceding_tool_use_ids = preceding_tool_use_ids
-    end
   end
 
   # Prompt suggestion message (type: 'prompt_suggestion')
-  class PromptSuggestionMessage
+  class PromptSuggestionMessage < Type
     attr_accessor :uuid, :session_id, :suggestion
-
-    def initialize(uuid: nil, session_id: nil, suggestion: nil)
-      @uuid = uuid
-      @session_id = session_id
-      @suggestion = suggestion
-    end
   end
 
   # Type constants for rate limit statuses
@@ -564,32 +381,28 @@ module ClaudeAgentSDK
   RATE_LIMIT_TYPES = %w[five_hour seven_day seven_day_opus seven_day_sonnet overage].freeze
 
   # Rate limit info with typed fields
-  class RateLimitInfo
+  class RateLimitInfo < Type
     attr_accessor :status, :resets_at, :rate_limit_type, :utilization,
                   :overage_status, :overage_resets_at, :overage_disabled_reason, :raw
 
-    def initialize(status:, resets_at: nil, rate_limit_type: nil, utilization: nil,
-                   overage_status: nil, overage_resets_at: nil, overage_disabled_reason: nil, raw: {})
-      @status = status
-      @resets_at = resets_at
-      @rate_limit_type = rate_limit_type
-      @utilization = utilization
-      @overage_status = overage_status
-      @overage_resets_at = overage_resets_at
-      @overage_disabled_reason = overage_disabled_reason
-      @raw = raw
+    def initialize(attributes = {})
+      super
+      @raw ||= {}
     end
   end
 
   # Rate limit event emitted when rate limit info changes
-  class RateLimitEvent
-    attr_accessor :rate_limit_info, :uuid, :session_id
+  class RateLimitEvent < Type
+    attr_accessor :uuid, :session_id, :raw_data
+    attr_reader :rate_limit_info
 
-    def initialize(rate_limit_info:, uuid:, session_id:, raw_data: nil)
-      @rate_limit_info = rate_limit_info
-      @uuid = uuid
-      @session_id = session_id
-      @raw_data = raw_data
+    def initialize(attributes = {})
+      super
+      @rate_limit_info ||= RateLimitInfo.new
+    end
+
+    def rate_limit_info=(value)
+      @rate_limit_info = value.is_a?(Hash) ? RateLimitInfo.new(value.merge(raw: value)) : value
     end
 
     # Backward-compatible accessor returning the full raw event payload
@@ -601,79 +414,50 @@ module ClaudeAgentSDK
   # Thinking configuration types
 
   # Adaptive thinking: uses a default budget of 32000 tokens
-  class ThinkingConfigAdaptive
-    attr_accessor :type
+  class ThinkingConfigAdaptive < Type
+    attr_reader :type
 
-    def initialize
+    def initialize(attributes = {})
+      super
       @type = 'adaptive'
     end
   end
 
   # Enabled thinking: uses a user-specified budget
-  class ThinkingConfigEnabled
-    attr_accessor :type, :budget_tokens
+  class ThinkingConfigEnabled < Type
+    attr_accessor :budget_tokens
+    attr_reader :type
 
-    def initialize(budget_tokens:)
+    def initialize(attributes = {})
+      super
       @type = 'enabled'
-      @budget_tokens = budget_tokens
     end
   end
 
   # Disabled thinking: sets thinking tokens to 0
-  class ThinkingConfigDisabled
-    attr_accessor :type
+  class ThinkingConfigDisabled < Type
+    attr_reader :type
 
-    def initialize
+    def initialize(attributes = {})
+      super
       @type = 'disabled'
     end
   end
 
   # Agent definition configuration
-  class AgentDefinition
+  class AgentDefinition < Type
     attr_accessor :description, :prompt, :tools, :disallowed_tools, :model, :skills, :memory, :mcp_servers,
                   :initial_prompt, :max_turns, :background, :effort, :permission_mode
-
-    def initialize(description:, prompt:, tools: nil, disallowed_tools: nil, model: nil, skills: nil,
-                   memory: nil, mcp_servers: nil, initial_prompt: nil, max_turns: nil,
-                   background: nil, effort: nil, permission_mode: nil)
-      @description = description
-      @prompt = prompt
-      @tools = tools
-      @disallowed_tools = disallowed_tools # Array of tool names to disallow
-      @model = model
-      @skills = skills # Array of skill names
-      @memory = memory # One of: 'user', 'project', 'local'
-      @mcp_servers = mcp_servers # Array of server names or config hashes
-      @initial_prompt = initial_prompt # Initial prompt sent when agent starts
-      @max_turns = max_turns # Maximum conversation turns for the agent
-      @background = background # Whether this agent runs in background
-      @effort = effort # See ClaudeAgentSDK::EFFORT_LEVELS or an Integer
-      @permission_mode = permission_mode # Permission mode for the agent
-    end
   end
 
   # Permission rule value
-  class PermissionRuleValue
+  class PermissionRuleValue < Type
     attr_accessor :tool_name, :rule_content
-
-    def initialize(tool_name:, rule_content: nil)
-      @tool_name = tool_name
-      @rule_content = rule_content
-    end
   end
 
   # Permission update configuration
-  class PermissionUpdate
+  class PermissionUpdate < Type
     attr_accessor :type, :rules, :behavior, :mode, :directories, :destination
-
-    def initialize(type:, rules: nil, behavior: nil, mode: nil, directories: nil, destination: nil)
-      @type = type
-      @rules = rules
-      @behavior = behavior
-      @mode = mode
-      @directories = directories
-      @destination = destination
-    end
 
     def to_h
       result = { type: @type }
@@ -701,452 +485,342 @@ module ClaudeAgentSDK
   end
 
   # Tool permission context
-  class ToolPermissionContext
+  class ToolPermissionContext < Type
     attr_accessor :signal, :suggestions, :tool_use_id, :agent_id
 
-    def initialize(signal: nil, suggestions: [], tool_use_id: nil, agent_id: nil)
-      @signal = signal
-      @suggestions = suggestions
-      @tool_use_id = tool_use_id # Unique ID for this tool call within the assistant message
-      @agent_id = agent_id # Sub-agent ID if running within an agent context
+    def initialize(attributes = {})
+      super
+      @suggestions ||= []
     end
   end
 
   # Permission results
-  class PermissionResultAllow
-    attr_accessor :behavior, :updated_input, :updated_permissions
+  class PermissionResultAllow < Type
+    attr_accessor :updated_input, :updated_permissions
+    attr_reader :behavior
 
-    def initialize(updated_input: nil, updated_permissions: nil)
+    def initialize(attributes = {})
+      super
       @behavior = 'allow'
-      @updated_input = updated_input
-      @updated_permissions = updated_permissions
     end
   end
 
-  class PermissionResultDeny
-    attr_accessor :behavior, :message, :interrupt
+  class PermissionResultDeny < Type
+    attr_accessor :message, :interrupt
+    attr_reader :behavior
 
-    def initialize(message: '', interrupt: false)
+    def initialize(attributes = {})
+      super
       @behavior = 'deny'
-      @message = message
-      @interrupt = interrupt
+      @message ||= ''
+      @interrupt = false if @interrupt.nil?
     end
   end
 
   # Hook matcher configuration
-  class HookMatcher
+  class HookMatcher < Type
     attr_accessor :matcher, :hooks, :timeout
 
-    def initialize(matcher: nil, hooks: [], timeout: nil)
-      @matcher = matcher
-      @hooks = hooks
-      @timeout = timeout # Timeout in seconds for hook execution
+    def initialize(attributes = {})
+      super
+      @hooks ||= []
     end
   end
 
   # Hook context passed to hook callbacks
-  class HookContext
+  class HookContext < Type
     attr_accessor :signal
-
-    def initialize(signal: nil)
-      @signal = signal
-    end
   end
 
   # Base hook input with common fields
-  class BaseHookInput
+  class BaseHookInput < Type
     attr_accessor :session_id, :transcript_path, :cwd, :permission_mode
-
-    def initialize(session_id: nil, transcript_path: nil, cwd: nil, permission_mode: nil)
-      @session_id = session_id
-      @transcript_path = transcript_path
-      @cwd = cwd
-      @permission_mode = permission_mode
-    end
+    attr_reader :hook_event_name
   end
 
   # PreToolUse hook input
   class PreToolUseHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :tool_name, :tool_input, :tool_use_id, :agent_id, :agent_type
+    attr_accessor :tool_name, :tool_input, :tool_use_id, :agent_id, :agent_type
 
-    def initialize(hook_event_name: 'PreToolUse', tool_name: nil, tool_input: nil, tool_use_id: nil,
-                   agent_id: nil, agent_type: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @tool_name = tool_name
-      @tool_input = tool_input
-      @tool_use_id = tool_use_id
-      @agent_id = agent_id
-      @agent_type = agent_type
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'PreToolUse'
     end
   end
 
   # PostToolUse hook input
   class PostToolUseHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :tool_name, :tool_input, :tool_response, :tool_use_id, :agent_id, :agent_type
+    attr_accessor :tool_name, :tool_input, :tool_response, :tool_use_id, :agent_id, :agent_type
 
-    def initialize(hook_event_name: 'PostToolUse', tool_name: nil, tool_input: nil, tool_response: nil,
-                   tool_use_id: nil, agent_id: nil, agent_type: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @tool_name = tool_name
-      @tool_input = tool_input
-      @tool_response = tool_response
-      @tool_use_id = tool_use_id
-      @agent_id = agent_id
-      @agent_type = agent_type
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'PostToolUse'
     end
   end
 
   # UserPromptSubmit hook input
   class UserPromptSubmitHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :prompt
+    attr_accessor :prompt
 
-    def initialize(hook_event_name: 'UserPromptSubmit', prompt: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @prompt = prompt
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'UserPromptSubmit'
     end
   end
 
   # Stop hook input
   class StopHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :stop_hook_active, :last_assistant_message
+    attr_accessor :stop_hook_active, :last_assistant_message
 
-    def initialize(hook_event_name: 'Stop', stop_hook_active: false, last_assistant_message: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @stop_hook_active = stop_hook_active
-      @last_assistant_message = last_assistant_message
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'Stop'
+      @stop_hook_active = false if @stop_hook_active.nil?
     end
   end
 
   # SubagentStop hook input
   class SubagentStopHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :stop_hook_active, :agent_id, :agent_transcript_path, :agent_type,
+    attr_accessor :stop_hook_active, :agent_id, :agent_transcript_path, :agent_type,
                   :last_assistant_message
 
-    def initialize(hook_event_name: 'SubagentStop', stop_hook_active: false, agent_id: nil,
-                   agent_transcript_path: nil, agent_type: nil, last_assistant_message: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @stop_hook_active = stop_hook_active
-      @agent_id = agent_id
-      @agent_transcript_path = agent_transcript_path
-      @agent_type = agent_type
-      @last_assistant_message = last_assistant_message
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'SubagentStop'
+      @stop_hook_active = false if @stop_hook_active.nil?
     end
   end
 
   # PostToolUseFailure hook input
   class PostToolUseFailureHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :tool_name, :tool_input, :tool_use_id, :error, :is_interrupt,
+    attr_accessor :tool_name, :tool_input, :tool_use_id, :error, :is_interrupt,
                   :agent_id, :agent_type
 
-    def initialize(hook_event_name: 'PostToolUseFailure', tool_name: nil, tool_input: nil, tool_use_id: nil,
-                   error: nil, is_interrupt: nil, agent_id: nil, agent_type: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @tool_name = tool_name
-      @tool_input = tool_input
-      @tool_use_id = tool_use_id
-      @error = error
-      @is_interrupt = is_interrupt
-      @agent_id = agent_id
-      @agent_type = agent_type
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'PostToolUseFailure'
     end
   end
 
   # Notification hook input
   class NotificationHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :message, :title, :notification_type
+    attr_accessor :message, :title, :notification_type
 
-    def initialize(hook_event_name: 'Notification', message: nil, title: nil, notification_type: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @message = message
-      @title = title
-      @notification_type = notification_type
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'Notification'
     end
   end
 
   # SubagentStart hook input
   class SubagentStartHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :agent_id, :agent_type
+    attr_accessor :agent_id, :agent_type
 
-    def initialize(hook_event_name: 'SubagentStart', agent_id: nil, agent_type: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @agent_id = agent_id
-      @agent_type = agent_type
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'SubagentStart'
     end
   end
 
   # PermissionRequest hook input
   class PermissionRequestHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :tool_name, :tool_input, :permission_suggestions, :agent_id, :agent_type
+    attr_accessor :tool_name, :tool_input, :permission_suggestions, :agent_id, :agent_type
 
-    def initialize(hook_event_name: 'PermissionRequest', tool_name: nil, tool_input: nil, permission_suggestions: nil,
-                   agent_id: nil, agent_type: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @tool_name = tool_name
-      @tool_input = tool_input
-      @permission_suggestions = permission_suggestions
-      @agent_id = agent_id
-      @agent_type = agent_type
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'PermissionRequest'
     end
   end
 
   # PreCompact hook input
   class PreCompactHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :trigger, :custom_instructions
+    attr_accessor :trigger, :custom_instructions
 
-    def initialize(hook_event_name: 'PreCompact', trigger: nil, custom_instructions: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @trigger = trigger
-      @custom_instructions = custom_instructions
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'PreCompact'
     end
   end
 
   # SessionStart hook input
   class SessionStartHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :source, :agent_type, :model
+    attr_accessor :source, :agent_type, :model
 
-    def initialize(hook_event_name: 'SessionStart', source: nil, agent_type: nil, model: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @source = source # "startup", "resume", "clear", "compact"
-      @agent_type = agent_type
-      @model = model
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'SessionStart'
     end
   end
 
   # SessionEnd hook input
   class SessionEndHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :reason
+    attr_accessor :reason
 
-    def initialize(hook_event_name: 'SessionEnd', reason: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @reason = reason
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'SessionEnd'
     end
   end
 
   # Setup hook input
   class SetupHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :trigger
+    attr_accessor :trigger
 
-    def initialize(hook_event_name: 'Setup', trigger: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @trigger = trigger # "init" or "maintenance"
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'Setup'
     end
   end
 
   # TeammateIdle hook input
   class TeammateIdleHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :teammate_name, :team_name
+    attr_accessor :teammate_name, :team_name
 
-    def initialize(hook_event_name: 'TeammateIdle', teammate_name: nil, team_name: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @teammate_name = teammate_name
-      @team_name = team_name
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'TeammateIdle'
     end
   end
 
   # TaskCompleted hook input
   class TaskCompletedHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :task_id, :task_subject, :task_description, :teammate_name, :team_name
+    attr_accessor :task_id, :task_subject, :task_description, :teammate_name, :team_name
 
-    def initialize(hook_event_name: 'TaskCompleted', task_id: nil, task_subject: nil, task_description: nil,
-                   teammate_name: nil, team_name: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @task_id = task_id
-      @task_subject = task_subject
-      @task_description = task_description
-      @teammate_name = teammate_name
-      @team_name = team_name
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'TaskCompleted'
     end
   end
 
   # ConfigChange hook input
   class ConfigChangeHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :source, :file_path
+    attr_accessor :source, :file_path
 
-    def initialize(hook_event_name: 'ConfigChange', source: nil, file_path: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @source = source # "user_settings", "project_settings", "local_settings", "policy_settings", "skills"
-      @file_path = file_path
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'ConfigChange'
     end
   end
 
   # WorktreeCreate hook input
   class WorktreeCreateHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :name
+    attr_accessor :name
 
-    def initialize(hook_event_name: 'WorktreeCreate', name: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @name = name
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'WorktreeCreate'
     end
   end
 
   # WorktreeRemove hook input
   class WorktreeRemoveHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :worktree_path
+    attr_accessor :worktree_path
 
-    def initialize(hook_event_name: 'WorktreeRemove', worktree_path: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @worktree_path = worktree_path
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'WorktreeRemove'
     end
   end
 
   # StopFailure hook input
   class StopFailureHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :error, :error_details, :last_assistant_message
+    attr_accessor :error, :error_details, :last_assistant_message
 
-    def initialize(hook_event_name: 'StopFailure', error: nil, error_details: nil,
-                   last_assistant_message: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @error = error
-      @error_details = error_details
-      @last_assistant_message = last_assistant_message
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'StopFailure'
     end
   end
 
   # PostCompact hook input
   class PostCompactHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :trigger, :compact_summary
+    attr_accessor :trigger, :compact_summary
 
-    def initialize(hook_event_name: 'PostCompact', trigger: nil, compact_summary: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @trigger = trigger # "manual" or "auto"
-      @compact_summary = compact_summary
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'PostCompact'
     end
   end
 
   # PermissionDenied hook input
   class PermissionDeniedHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :tool_name, :tool_input, :tool_use_id, :reason, :agent_id, :agent_type
+    attr_accessor :tool_name, :tool_input, :tool_use_id, :reason, :agent_id, :agent_type
 
-    def initialize(hook_event_name: 'PermissionDenied', tool_name: nil, tool_input: nil, tool_use_id: nil,
-                   reason: nil, agent_id: nil, agent_type: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @tool_name = tool_name
-      @tool_input = tool_input
-      @tool_use_id = tool_use_id
-      @reason = reason
-      @agent_id = agent_id
-      @agent_type = agent_type
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'PermissionDenied'
     end
   end
 
   # TaskCreated hook input
   class TaskCreatedHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :task_id, :task_subject, :task_description, :teammate_name, :team_name
+    attr_accessor :task_id, :task_subject, :task_description, :teammate_name, :team_name
 
-    def initialize(hook_event_name: 'TaskCreated', task_id: nil, task_subject: nil, task_description: nil,
-                   teammate_name: nil, team_name: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @task_id = task_id
-      @task_subject = task_subject
-      @task_description = task_description
-      @teammate_name = teammate_name
-      @team_name = team_name
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'TaskCreated'
     end
   end
 
   # Elicitation hook input
   class ElicitationHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :mcp_server_name, :message, :mode, :url,
+    attr_accessor :mcp_server_name, :message, :mode, :url,
                   :elicitation_id, :requested_schema
 
-    def initialize(hook_event_name: 'Elicitation', mcp_server_name: nil, message: nil, mode: nil,
-                   url: nil, elicitation_id: nil, requested_schema: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @mcp_server_name = mcp_server_name
-      @message = message
-      @mode = mode
-      @url = url
-      @elicitation_id = elicitation_id
-      @requested_schema = requested_schema
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'Elicitation'
     end
   end
 
   # ElicitationResult hook input
   class ElicitationResultHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :mcp_server_name, :elicitation_id, :mode, :action, :content
+    attr_accessor :mcp_server_name, :elicitation_id, :mode, :action, :content
 
-    def initialize(hook_event_name: 'ElicitationResult', mcp_server_name: nil, elicitation_id: nil,
-                   mode: nil, action: nil, content: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @mcp_server_name = mcp_server_name
-      @elicitation_id = elicitation_id
-      @mode = mode
-      @action = action
-      @content = content
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'ElicitationResult'
     end
   end
 
   # InstructionsLoaded hook input
   class InstructionsLoadedHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :file_path, :memory_type, :load_reason, :globs, :trigger_file_path
+    attr_accessor :file_path, :memory_type, :load_reason, :globs, :trigger_file_path
 
-    def initialize(hook_event_name: 'InstructionsLoaded', file_path: nil, memory_type: nil,
-                   load_reason: nil, globs: nil, trigger_file_path: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @file_path = file_path
-      @memory_type = memory_type
-      @load_reason = load_reason
-      @globs = globs
-      @trigger_file_path = trigger_file_path
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'InstructionsLoaded'
     end
   end
 
   # CwdChanged hook input
   class CwdChangedHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :old_cwd, :new_cwd
+    attr_accessor :old_cwd, :new_cwd
 
-    def initialize(hook_event_name: 'CwdChanged', old_cwd: nil, new_cwd: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @old_cwd = old_cwd
-      @new_cwd = new_cwd
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'CwdChanged'
     end
   end
 
   # FileChanged hook input
   class FileChangedHookInput < BaseHookInput
-    attr_accessor :hook_event_name, :file_path, :event
+    attr_accessor :file_path, :event
 
-    def initialize(hook_event_name: 'FileChanged', file_path: nil, event: nil, **base_args)
-      super(**base_args)
-      @hook_event_name = hook_event_name
-      @file_path = file_path
-      @event = event # "change", "add", or "unlink"
+    def initialize(attributes = {})
+      super
+      @hook_event_name = 'FileChanged'
     end
   end
 
   # Setup hook specific output
-  class SetupHookSpecificOutput
-    attr_accessor :hook_event_name, :additional_context
+  class SetupHookSpecificOutput < Type
+    attr_accessor :additional_context
+    attr_reader :hook_event_name
 
-    def initialize(additional_context: nil)
+    def initialize(attributes = {})
+      super
       @hook_event_name = 'Setup'
-      @additional_context = additional_context
     end
 
     def to_h
@@ -1157,17 +831,14 @@ module ClaudeAgentSDK
   end
 
   # PreToolUse hook specific output
-  class PreToolUseHookSpecificOutput
-    attr_accessor :hook_event_name, :permission_decision, :permission_decision_reason,
+  class PreToolUseHookSpecificOutput < Type
+    attr_accessor :permission_decision, :permission_decision_reason,
                   :updated_input, :additional_context
+    attr_reader :hook_event_name
 
-    def initialize(permission_decision: nil, permission_decision_reason: nil, updated_input: nil,
-                   additional_context: nil)
+    def initialize(attributes = {})
+      super
       @hook_event_name = 'PreToolUse'
-      @permission_decision = permission_decision # 'allow', 'deny', or 'ask'
-      @permission_decision_reason = permission_decision_reason
-      @updated_input = updated_input
-      @additional_context = additional_context
     end
 
     def to_h
@@ -1181,13 +852,13 @@ module ClaudeAgentSDK
   end
 
   # PostToolUse hook specific output
-  class PostToolUseHookSpecificOutput
-    attr_accessor :hook_event_name, :additional_context, :updated_mcp_tool_output
+  class PostToolUseHookSpecificOutput < Type
+    attr_accessor :additional_context, :updated_mcp_tool_output
+    attr_reader :hook_event_name
 
-    def initialize(additional_context: nil, updated_mcp_tool_output: nil)
+    def initialize(attributes = {})
+      super
       @hook_event_name = 'PostToolUse'
-      @additional_context = additional_context
-      @updated_mcp_tool_output = updated_mcp_tool_output
     end
 
     def to_h
@@ -1199,12 +870,13 @@ module ClaudeAgentSDK
   end
 
   # PostToolUseFailure hook specific output
-  class PostToolUseFailureHookSpecificOutput
-    attr_accessor :hook_event_name, :additional_context
+  class PostToolUseFailureHookSpecificOutput < Type
+    attr_accessor :additional_context
+    attr_reader :hook_event_name
 
-    def initialize(additional_context: nil)
+    def initialize(attributes = {})
+      super
       @hook_event_name = 'PostToolUseFailure'
-      @additional_context = additional_context
     end
 
     def to_h
@@ -1215,12 +887,13 @@ module ClaudeAgentSDK
   end
 
   # UserPromptSubmit hook specific output
-  class UserPromptSubmitHookSpecificOutput
-    attr_accessor :hook_event_name, :additional_context
+  class UserPromptSubmitHookSpecificOutput < Type
+    attr_accessor :additional_context
+    attr_reader :hook_event_name
 
-    def initialize(additional_context: nil)
+    def initialize(attributes = {})
+      super
       @hook_event_name = 'UserPromptSubmit'
-      @additional_context = additional_context
     end
 
     def to_h
@@ -1231,12 +904,13 @@ module ClaudeAgentSDK
   end
 
   # Notification hook specific output
-  class NotificationHookSpecificOutput
-    attr_accessor :hook_event_name, :additional_context
+  class NotificationHookSpecificOutput < Type
+    attr_accessor :additional_context
+    attr_reader :hook_event_name
 
-    def initialize(additional_context: nil)
+    def initialize(attributes = {})
+      super
       @hook_event_name = 'Notification'
-      @additional_context = additional_context
     end
 
     def to_h
@@ -1247,12 +921,13 @@ module ClaudeAgentSDK
   end
 
   # SubagentStart hook specific output
-  class SubagentStartHookSpecificOutput
-    attr_accessor :hook_event_name, :additional_context
+  class SubagentStartHookSpecificOutput < Type
+    attr_accessor :additional_context
+    attr_reader :hook_event_name
 
-    def initialize(additional_context: nil)
+    def initialize(attributes = {})
+      super
       @hook_event_name = 'SubagentStart'
-      @additional_context = additional_context
     end
 
     def to_h
@@ -1263,12 +938,13 @@ module ClaudeAgentSDK
   end
 
   # PermissionRequest hook specific output
-  class PermissionRequestHookSpecificOutput
-    attr_accessor :hook_event_name, :decision
+  class PermissionRequestHookSpecificOutput < Type
+    attr_accessor :decision
+    attr_reader :hook_event_name
 
-    def initialize(decision: nil)
+    def initialize(attributes = {})
+      super
       @hook_event_name = 'PermissionRequest'
-      @decision = decision
     end
 
     def to_h
@@ -1279,12 +955,13 @@ module ClaudeAgentSDK
   end
 
   # SessionStart hook specific output
-  class SessionStartHookSpecificOutput
-    attr_accessor :hook_event_name, :additional_context
+  class SessionStartHookSpecificOutput < Type
+    attr_accessor :additional_context
+    attr_reader :hook_event_name
 
-    def initialize(additional_context: nil)
+    def initialize(attributes = {})
+      super
       @hook_event_name = 'SessionStart'
-      @additional_context = additional_context
     end
 
     def to_h
@@ -1295,12 +972,14 @@ module ClaudeAgentSDK
   end
 
   # PermissionDenied hook specific output
-  class PermissionDeniedHookSpecificOutput
-    attr_accessor :hook_event_name, :retry
+  class PermissionDeniedHookSpecificOutput < Type
+    attr_accessor :retry
+    attr_reader :hook_event_name
 
-    def initialize(retry_: false)
+    def initialize(attributes = {})
+      super
       @hook_event_name = 'PermissionDenied'
-      @retry = retry_
+      @retry = false if @retry.nil?
     end
 
     def to_h
@@ -1311,12 +990,13 @@ module ClaudeAgentSDK
   end
 
   # CwdChanged hook specific output
-  class CwdChangedHookSpecificOutput
-    attr_accessor :hook_event_name, :watch_paths
+  class CwdChangedHookSpecificOutput < Type
+    attr_accessor :watch_paths
+    attr_reader :hook_event_name
 
-    def initialize(watch_paths: nil)
+    def initialize(attributes = {})
+      super
       @hook_event_name = 'CwdChanged'
-      @watch_paths = watch_paths
     end
 
     def to_h
@@ -1327,12 +1007,13 @@ module ClaudeAgentSDK
   end
 
   # FileChanged hook specific output
-  class FileChangedHookSpecificOutput
-    attr_accessor :hook_event_name, :watch_paths
+  class FileChangedHookSpecificOutput < Type
+    attr_accessor :watch_paths
+    attr_reader :hook_event_name
 
-    def initialize(watch_paths: nil)
+    def initialize(attributes = {})
+      super
       @hook_event_name = 'FileChanged'
-      @watch_paths = watch_paths
     end
 
     def to_h
@@ -1343,12 +1024,12 @@ module ClaudeAgentSDK
   end
 
   # Async hook JSON output
-  class AsyncHookJSONOutput
+  class AsyncHookJSONOutput < Type
     attr_accessor :async, :async_timeout
 
-    def initialize(async: true, async_timeout: nil)
-      @async = async
-      @async_timeout = async_timeout
+    def initialize(attributes = {})
+      super
+      @async = true if @async.nil?
     end
 
     def to_h
@@ -1359,19 +1040,14 @@ module ClaudeAgentSDK
   end
 
   # Sync hook JSON output
-  class SyncHookJSONOutput
+  class SyncHookJSONOutput < Type
     attr_accessor :continue, :suppress_output, :stop_reason, :decision,
                   :system_message, :reason, :hook_specific_output
 
-    def initialize(continue: true, suppress_output: false, stop_reason: nil, decision: nil,
-                   system_message: nil, reason: nil, hook_specific_output: nil)
-      @continue = continue
-      @suppress_output = suppress_output
-      @stop_reason = stop_reason
-      @decision = decision
-      @system_message = system_message
-      @reason = reason
-      @hook_specific_output = hook_specific_output
+    def initialize(attributes = {})
+      super
+      @continue = true if @continue.nil?
+      @suppress_output = false if @suppress_output.nil?
     end
 
     def to_h
@@ -1392,63 +1068,44 @@ module ClaudeAgentSDK
   MCP_SERVER_CONNECTION_STATUSES = %w[connected failed needs-auth pending disabled].freeze
 
   # MCP server info (name and version)
-  class McpServerInfo
+  class McpServerInfo < Type
     attr_accessor :name, :version
-
-    def initialize(name:, version: nil)
-      @name = name
-      @version = version
-    end
   end
 
   # MCP tool annotation hints
-  class McpToolAnnotations
+  class McpToolAnnotations < Type
     attr_accessor :read_only, :destructive, :open_world
 
-    def initialize(read_only: nil, destructive: nil, open_world: nil)
-      @read_only = read_only
-      @destructive = destructive
-      @open_world = open_world
-    end
-
+    # Backwards-compatible parse; returns nil for nil input.
     def self.parse(data)
-      return nil unless data
-
-      new(
-        read_only: data.key?(:readOnly) ? data[:readOnly] : data[:read_only],
-        destructive: data[:destructive],
-        open_world: data.key?(:openWorld) ? data[:openWorld] : data[:open_world]
-      )
+      from_hash(data)
     end
   end
 
   # MCP tool info (name, description, annotations)
-  class McpToolInfo
-    attr_accessor :name, :description, :annotations
+  class McpToolInfo < Type
+    attr_accessor :name, :description
+    attr_reader :annotations
 
-    def initialize(name:, description: nil, annotations: nil)
-      @name = name
-      @description = description
-      @annotations = annotations
+    def annotations=(value)
+      @annotations = value.is_a?(Hash) ? McpToolAnnotations.new(value) : value
     end
 
+    # Backwards-compatible parse; returns nil for nil input.
     def self.parse(data)
-      new(
-        name: data[:name],
-        description: data[:description],
-        annotations: McpToolAnnotations.parse(data[:annotations])
-      )
+      from_hash(data)
     end
   end
 
   # Output-only serializable version of McpSdkServerConfig (without live instance)
   # Returned in MCP status responses
-  class McpSdkServerConfigStatus
-    attr_accessor :type, :name
+  class McpSdkServerConfigStatus < Type
+    attr_accessor :name
+    attr_reader :type
 
-    def initialize(type: 'sdk', name:)
-      @type = type
-      @name = name
+    def initialize(attributes = {})
+      super
+      @type = 'sdk'
     end
 
     def to_h
@@ -1458,13 +1115,13 @@ module ClaudeAgentSDK
 
   # Claude.ai proxy MCP server config
   # Output-only type that appears in status responses for servers proxied through Claude.ai
-  class McpClaudeAIProxyServerConfig
-    attr_accessor :type, :url, :id
+  class McpClaudeAIProxyServerConfig < Type
+    attr_accessor :url, :id
+    attr_reader :type
 
-    def initialize(type: 'claudeai-proxy', url:, id:)
-      @type = type
-      @url = url
-      @id = id
+    def initialize(attributes = {})
+      super
+      @type = 'claudeai-proxy'
     end
 
     def to_h
@@ -1473,37 +1130,30 @@ module ClaudeAgentSDK
   end
 
   # Status of a single MCP server connection
-  class McpServerStatus
-    attr_accessor :name, :status, :server_info, :error, :config, :scope, :tools
+  class McpServerStatus < Type
+    attr_accessor :name, :status, :error, :scope
+    attr_reader :server_info, :config, :tools
 
-    def initialize(name:, status:, server_info: nil, error: nil, config: nil, scope: nil, tools: nil)
-      @name = name
-      @status = status
-      @server_info = server_info
-      @error = error
-      @config = config
-      @scope = scope
-      @tools = tools
+    def server_info=(value)
+      @server_info = value.is_a?(Hash) ? McpServerInfo.new(value) : value
     end
 
-    def self.parse(data)
-      server_info = (McpServerInfo.new(name: data[:serverInfo][:name], version: data[:serverInfo][:version]) if data[:serverInfo])
-      tools = data[:tools]&.map { |t| McpToolInfo.parse(t) }
-      config = parse_config(data[:config])
+    def tools=(value)
+      @tools = value.is_a?(Array) ? value.map { |t| t.is_a?(Hash) ? McpToolInfo.new(t) : t } : value
+    end
 
-      new(
-        name: data[:name],
-        status: data[:status],
-        server_info: server_info,
-        error: data[:error],
-        config: config,
-        scope: data[:scope],
-        tools: tools
-      )
+    def config=(value)
+      @config = self.class.parse_config(value) || value
+    end
+
+    # Backwards-compatible parse; normalizes camelCase `serverInfo` and
+    # polymorphically builds the nested `config`.
+    def self.parse(data)
+      from_hash(data)
     end
 
     def self.parse_config(config)
-      return config unless config.is_a?(Hash) && config[:type]
+      return nil unless config.is_a?(Hash) && config[:type]
 
       case config[:type]
       when 'claudeai-proxy'
@@ -1517,28 +1167,27 @@ module ClaudeAgentSDK
   end
 
   # Response from get_mcp_status containing all server statuses
-  class McpStatusResponse
-    attr_accessor :mcp_servers
+  class McpStatusResponse < Type
+    attr_reader :mcp_servers
 
-    def initialize(mcp_servers:)
-      @mcp_servers = mcp_servers
+    def mcp_servers=(value)
+      @mcp_servers = value.is_a?(Array) ? value.map { |s| s.is_a?(Hash) ? McpServerStatus.new(s) : s } : value
     end
 
+    # Backwards-compatible parse; returns nil for nil input.
     def self.parse(data)
-      servers = (data[:mcpServers] || []).map { |s| McpServerStatus.parse(s) }
-      new(mcp_servers: servers)
+      from_hash(data)
     end
   end
 
   # MCP Server configurations
-  class McpStdioServerConfig
-    attr_accessor :type, :command, :args, :env
+  class McpStdioServerConfig < Type
+    attr_accessor :command, :args, :env
+    attr_reader :type
 
-    def initialize(command:, args: nil, env: nil, type: 'stdio')
-      @type = type
-      @command = command
-      @args = args
-      @env = env
+    def initialize(attributes = {})
+      super
+      @type = 'stdio'
     end
 
     def to_h
@@ -1549,13 +1198,13 @@ module ClaudeAgentSDK
     end
   end
 
-  class McpSSEServerConfig
-    attr_accessor :type, :url, :headers
+  class McpSSEServerConfig < Type
+    attr_accessor :url, :headers
+    attr_reader :type
 
-    def initialize(url:, headers: nil)
+    def initialize(attributes = {})
+      super
       @type = 'sse'
-      @url = url
-      @headers = headers
     end
 
     def to_h
@@ -1565,13 +1214,13 @@ module ClaudeAgentSDK
     end
   end
 
-  class McpHttpServerConfig
-    attr_accessor :type, :url, :headers
+  class McpHttpServerConfig < Type
+    attr_accessor :url, :headers
+    attr_reader :type
 
-    def initialize(url:, headers: nil)
+    def initialize(attributes = {})
+      super
       @type = 'http'
-      @url = url
-      @headers = headers
     end
 
     def to_h
@@ -1581,13 +1230,13 @@ module ClaudeAgentSDK
     end
   end
 
-  class McpSdkServerConfig
-    attr_accessor :type, :name, :instance
+  class McpSdkServerConfig < Type
+    attr_accessor :name, :instance
+    attr_reader :type
 
-    def initialize(name:, instance:)
+    def initialize(attributes = {})
+      super
       @type = 'sdk'
-      @name = name
-      @instance = instance
     end
 
     def to_h
@@ -1596,14 +1245,13 @@ module ClaudeAgentSDK
   end
 
   # SDK Plugin configuration
-  class SdkPluginConfig
-    attr_accessor :type, :path
+  class SdkPluginConfig < Type
+    attr_accessor :path
+    attr_reader :type
 
-    def initialize(path:, type: 'local')
-      raise ArgumentError, "unsupported plugin type: #{type}" unless %w[local plugin].include?(type)
-
+    def initialize(attributes = {})
+      super
       @type = 'local'
-      @path = path
     end
 
     def to_h
@@ -1612,28 +1260,10 @@ module ClaudeAgentSDK
   end
 
   # Sandbox network configuration
-  class SandboxNetworkConfig
+  class SandboxNetworkConfig < Type
     attr_accessor :allowed_domains, :allow_managed_domains_only,
                   :allow_unix_sockets, :allow_all_unix_sockets, :allow_local_binding,
                   :http_proxy_port, :socks_proxy_port
-
-    def initialize(
-      allowed_domains: nil,
-      allow_managed_domains_only: nil,
-      allow_unix_sockets: nil,
-      allow_all_unix_sockets: nil,
-      allow_local_binding: nil,
-      http_proxy_port: nil,
-      socks_proxy_port: nil
-    )
-      @allowed_domains = allowed_domains # Array of domain strings
-      @allow_managed_domains_only = allow_managed_domains_only
-      @allow_unix_sockets = allow_unix_sockets # macOS only: Array of socket paths
-      @allow_all_unix_sockets = allow_all_unix_sockets
-      @allow_local_binding = allow_local_binding
-      @http_proxy_port = http_proxy_port
-      @socks_proxy_port = socks_proxy_port
-    end
 
     def to_h
       result = {}
@@ -1649,17 +1279,8 @@ module ClaudeAgentSDK
   end
 
   # Sandbox filesystem configuration
-  class SandboxFilesystemConfig
+  class SandboxFilesystemConfig < Type
     attr_accessor :allow_write, :deny_write, :deny_read, :allow_read, :allow_managed_read_paths_only
-
-    def initialize(allow_write: nil, deny_write: nil, deny_read: nil, allow_read: nil,
-                   allow_managed_read_paths_only: nil)
-      @allow_write = allow_write # Array of paths to allow writing
-      @deny_write = deny_write   # Array of paths to deny writing
-      @deny_read = deny_read     # Array of paths to deny reading
-      @allow_read = allow_read   # Array of paths to re-allow reading within denyRead
-      @allow_managed_read_paths_only = allow_managed_read_paths_only
-    end
 
     def to_h
       result = {}
@@ -1673,37 +1294,11 @@ module ClaudeAgentSDK
   end
 
   # Sandbox settings for isolated command execution
-  class SandboxSettings
+  class SandboxSettings < Type
     attr_accessor :enabled, :fail_if_unavailable, :auto_allow_bash_if_sandboxed,
                   :excluded_commands, :allow_unsandboxed_commands, :network, :filesystem,
                   :ignore_violations, :enable_weaker_nested_sandbox,
                   :enable_weaker_network_isolation, :ripgrep
-
-    def initialize(
-      enabled: nil,
-      fail_if_unavailable: nil,
-      auto_allow_bash_if_sandboxed: nil,
-      excluded_commands: nil,
-      allow_unsandboxed_commands: nil,
-      network: nil,
-      filesystem: nil,
-      ignore_violations: nil,
-      enable_weaker_nested_sandbox: nil,
-      enable_weaker_network_isolation: nil,
-      ripgrep: nil
-    )
-      @enabled = enabled
-      @fail_if_unavailable = fail_if_unavailable
-      @auto_allow_bash_if_sandboxed = auto_allow_bash_if_sandboxed
-      @excluded_commands = excluded_commands # Array of commands to exclude
-      @allow_unsandboxed_commands = allow_unsandboxed_commands
-      @network = network # SandboxNetworkConfig instance
-      @filesystem = filesystem # SandboxFilesystemConfig instance
-      @ignore_violations = ignore_violations # Hash of { category => [patterns] }
-      @enable_weaker_nested_sandbox = enable_weaker_nested_sandbox
-      @enable_weaker_network_isolation = enable_weaker_network_isolation # macOS only
-      @ripgrep = ripgrep # Hash with :command and optional :args
-    end
 
     def to_h
       result = {}
@@ -1723,23 +1318,15 @@ module ClaudeAgentSDK
   end
 
   # Result of a session fork operation
-  class ForkSessionResult
+  class ForkSessionResult < Type
     attr_accessor :session_id
-
-    def initialize(session_id:)
-      @session_id = session_id
-    end
   end
 
   # API-side task budget in tokens.
   # When set, the model is made aware of its remaining token budget so it can
   # pace tool use and wrap up before the limit.
-  class TaskBudget
+  class TaskBudget < Type
     attr_accessor :total
-
-    def initialize(total:)
-      @total = total
-    end
 
     def to_h
       { total: @total }
@@ -1747,12 +1334,13 @@ module ClaudeAgentSDK
   end
 
   # System prompt file configuration — loads system prompt from a file path
-  class SystemPromptFile
-    attr_accessor :type, :path
+  class SystemPromptFile < Type
+    attr_accessor :path
+    attr_reader :type
 
-    def initialize(path:)
+    def initialize(attributes = {})
+      super
       @type = 'file'
-      @path = path
     end
 
     def to_h
@@ -1761,14 +1349,13 @@ module ClaudeAgentSDK
   end
 
   # System prompt preset configuration
-  class SystemPromptPreset
-    attr_accessor :type, :preset, :append, :exclude_dynamic_sections
+  class SystemPromptPreset < Type
+    attr_reader :type
+    attr_accessor :preset, :append, :exclude_dynamic_sections
 
-    def initialize(preset:, append: nil, exclude_dynamic_sections: nil)
+    def initialize(attributes = {})
+      super
       @type = 'preset'
-      @preset = preset
-      @append = append
-      @exclude_dynamic_sections = exclude_dynamic_sections
     end
 
     def to_h
@@ -1780,12 +1367,13 @@ module ClaudeAgentSDK
   end
 
   # Tools preset configuration
-  class ToolsPreset
-    attr_accessor :type, :preset
+  class ToolsPreset < Type
+    attr_reader :type
+    attr_accessor :preset
 
-    def initialize(preset:)
+    def initialize(attributes = {})
+      super
       @type = 'preset'
-      @preset = preset
     end
 
     def to_h
@@ -1794,7 +1382,7 @@ module ClaudeAgentSDK
   end
 
   # Claude Agent Options for configuring queries
-  class ClaudeAgentOptions
+  class ClaudeAgentOptions < Type
     attr_accessor :allowed_tools, :system_prompt, :mcp_servers, :permission_mode,
                   :continue_conversation, :resume, :session_id, :max_turns, :disallowed_tools,
                   :model, :permission_prompt_tool_name, :cwd, :cli_path, :settings,
@@ -1806,52 +1394,84 @@ module ClaudeAgentSDK
                   :betas, :tools, :sandbox, :enable_file_checkpointing, :append_allowed_tools,
                   :thinking, :effort, :bare, :observers, :task_budget
 
-    # Non-nil defaults for options that need them.
-    # Keys absent from here default to nil.
-    OPTION_DEFAULTS = {
-      allowed_tools: [], disallowed_tools: [], add_dirs: [],
-      mcp_servers: {}, env: {}, extra_args: {},
-      continue_conversation: false, include_partial_messages: false,
-      fork_session: false, enable_file_checkpointing: false,
-      observers: []
-    }.freeze
+    def initialize(attributes = {})
+      self.fork_session = false
+      self.continue_conversation = false
+      self.include_partial_messages = false
+      self.enable_file_checkpointing = false
 
-    # Valid option names derived from attr_accessor declarations.
-    VALID_OPTIONS = instance_methods.grep(/=\z/).map { |m| m.to_s.chomp('=').to_sym }.freeze
+      super(merge_with_defaults(attributes || {}))
 
-    # Using **kwargs lets us distinguish "caller passed allowed_tools: []"
-    # from "caller omitted allowed_tools" — critical for correct merge with
-    # configured defaults.
-    def initialize(**kwargs)
-      unknown = kwargs.keys - VALID_OPTIONS
-      raise ArgumentError, "unknown keyword#{'s' if unknown.size > 1}: #{unknown.join(', ')}" if unknown.any?
-
-      merged = merge_with_defaults(kwargs)
-      OPTION_DEFAULTS.merge(merged).each do |key, value|
-        instance_variable_set(:"@#{key}", value)
-      end
+      # Non-nil defaults for options that need them.
+      self.env              ||= {}
+      self.extra_args       ||= {}
+      self.mcp_servers      ||= {}
+      self.add_dirs         ||= []
+      self.observers        ||= []
+      self.allowed_tools    ||= []
+      self.disallowed_tools ||= []
     end
 
     def dup_with(**changes)
       new_options = self.dup
-      changes.each { |key, value| new_options.send(:"#{key}=", value) }
+      changes.each { |key, value| new_options[key] = value }
       new_options
+    end
+
+    def bare?
+      !!bare
+    end
+
+    def bare=(value)
+      @bare = coerce_boolean(value)
+    end
+
+    def fork_session?
+      !!fork_session
+    end
+
+    def fork_session=(value)
+      @fork_session = coerce_boolean(value)
+    end
+
+    def enable_file_checkpointing?
+      !!enable_file_checkpointing
+    end
+
+    def enable_file_checkpointing=(value)
+      @enable_file_checkpointing = coerce_boolean(value)
+    end
+
+    def include_partial_messages?
+      !!include_partial_messages
+    end
+
+    def include_partial_messages=(value)
+      @include_partial_messages = coerce_boolean(value)
+    end
+
+    def continue_conversation?
+      !!continue_conversation
+    end
+
+    def continue_conversation=(value)
+      @continue_conversation = coerce_boolean(value)
     end
 
     private
 
-    # Merge caller-provided kwargs with configured defaults.
+    # Merge caller-provided attributes with configured defaults.
     # Only keys the caller explicitly passed are treated as overrides;
-    # method-signature defaults ([], {}, false) are NOT in kwargs unless the caller wrote them.
-    def merge_with_defaults(kwargs)
-      return OPTION_DEFAULTS.merge(kwargs) unless defined?(ClaudeAgentSDK) && ClaudeAgentSDK.respond_to?(:default_options)
+    # method-signature defaults ([], {}, false) are NOT present unless the caller wrote them.
+    def merge_with_defaults(attributes)
+      return attributes unless defined?(ClaudeAgentSDK) && ClaudeAgentSDK.respond_to?(:default_options)
 
       defaults = ClaudeAgentSDK.default_options
-      return OPTION_DEFAULTS.merge(kwargs) unless defaults.any?
+      return attributes unless defaults.any?
 
       # Start from configured defaults (deep dup hashes to prevent mutation)
       result = defaults.transform_values { |v| v.is_a?(Hash) ? v.dup : v }
-      kwargs.each do |key, value|
+      attributes.each do |key, value|
         default_val = result[key]
         result[key] = if value.nil?
                         default_val # nil means "no preference" — keep the configured default
@@ -1861,46 +1481,22 @@ module ClaudeAgentSDK
                         value
                       end
       end
-      OPTION_DEFAULTS.merge(result)
+      result
     end
   end
 
   # SDK MCP Tool definition
-  class SdkMcpTool
+  class SdkMcpTool < Type
     attr_accessor :name, :description, :input_schema, :handler, :annotations, :meta
-
-    def initialize(name:, description:, input_schema:, handler:, annotations: nil, meta: nil)
-      @name = name
-      @description = description
-      @input_schema = input_schema
-      @handler = handler
-      @annotations = annotations # MCP tool annotations (e.g., { title: '...', readOnlyHint: true })
-      @meta = meta # MCP _meta field (e.g., { 'anthropic/maxResultSizeChars' => 100000 })
-    end
   end
 
   # SDK MCP Resource definition
-  class SdkMcpResource
+  class SdkMcpResource < Type
     attr_accessor :uri, :name, :description, :mime_type, :reader
-
-    def initialize(uri:, name:, description: nil, mime_type: nil, reader:)
-      @uri = uri
-      @name = name
-      @description = description
-      @mime_type = mime_type
-      @reader = reader
-    end
   end
 
   # SDK MCP Prompt definition
-  class SdkMcpPrompt
+  class SdkMcpPrompt < Type
     attr_accessor :name, :description, :arguments, :generator
-
-    def initialize(name:, description: nil, arguments: nil, generator:)
-      @name = name
-      @description = description
-      @arguments = arguments
-      @generator = generator
-    end
   end
 end

--- a/lib/claude_agent_sdk/types.rb
+++ b/lib/claude_agent_sdk/types.rb
@@ -60,12 +60,10 @@ module ClaudeAgentSDK
   # Base class for all types.
   class Type
     def self.wrap(object)
-      case object
-      when self
-        object
-      else
-        new(object)
-      end
+      return object if object.is_a?(self)
+      return nil if object.nil?
+
+      new(object)
     end
 
     def self.from_hash(hash)
@@ -1505,6 +1503,16 @@ module ClaudeAgentSDK
     end
 
     private
+
+    # Strict key validation: unlike other Type subclasses (which silently drop
+    # unknown keys for forward-compat with newer CLI output), ClaudeAgentOptions
+    # is a developer-facing config object — typos should fail loudly.
+    def assign_attribute(name, value)
+      setter = :"#{normalize_name(name)}="
+      raise ArgumentError, "unknown ClaudeAgentOptions option: #{name.inspect}" unless respond_to?(setter)
+
+      public_send(setter, value)
+    end
 
     # Merge caller-provided attributes with configured defaults.
     # Only keys the caller explicitly passed are treated as overrides;

--- a/lib/claude_agent_sdk/types.rb
+++ b/lib/claude_agent_sdk/types.rb
@@ -138,13 +138,13 @@ module ClaudeAgentSDK
 
     FALSE_VALUES = [
       false, 0,
-      "0", :"0",
+      "0", :'0',
       "f", :f,
       "F", :F,
-      "false", :false,
+      "false", :false, # rubocop:disable Lint/BooleanSymbol
       "FALSE", :FALSE,
       "off", :off,
-      "OFF", :OFF,
+      "OFF", :OFF
     ].to_set.freeze
 
     private_constant :FALSE_VALUES
@@ -1175,7 +1175,11 @@ module ClaudeAgentSDK
     end
 
     def tools=(value)
-      @tools = value.is_a?(Array) ? value.map { |t| t.is_a?(Hash) ? McpToolInfo.new(t) : t } : value
+      @tools = if value.is_a?(Array)
+                 value.map { |t| t.is_a?(Hash) ? McpToolInfo.new(t) : t }
+               else
+                 value
+               end
     end
 
     def config=(value)
@@ -1207,7 +1211,11 @@ module ClaudeAgentSDK
     attr_reader :mcp_servers
 
     def mcp_servers=(value)
-      @mcp_servers = value.is_a?(Array) ? value.map { |s| s.is_a?(Hash) ? McpServerStatus.new(s) : s } : value
+      @mcp_servers = if value.is_a?(Array)
+                       value.map { |s| s.is_a?(Hash) ? McpServerStatus.new(s) : s }
+                     else
+                       value
+                     end
     end
 
     # Backwards-compatible parse; returns nil for nil input.
@@ -1420,15 +1428,17 @@ module ClaudeAgentSDK
   # Claude Agent Options for configuring queries
   class ClaudeAgentOptions < Type
     attr_accessor :allowed_tools, :system_prompt, :mcp_servers, :permission_mode,
-                  :continue_conversation, :resume, :session_id, :max_turns, :disallowed_tools,
+                  :resume, :session_id, :max_turns, :disallowed_tools,
                   :model, :permission_prompt_tool_name, :cwd, :cli_path, :settings,
                   :add_dirs, :env, :extra_args, :max_buffer_size, :stderr,
-                  :can_use_tool, :hooks, :user, :include_partial_messages,
-                  :fork_session, :agents, :setting_sources,
+                  :can_use_tool, :hooks, :user,
+                  :agents, :setting_sources,
                   :output_format, :max_budget_usd, :max_thinking_tokens,
                   :fallback_model, :plugins, :debug_stderr,
-                  :betas, :tools, :sandbox, :enable_file_checkpointing, :append_allowed_tools,
-                  :thinking, :effort, :bare, :observers, :task_budget
+                  :betas, :tools, :sandbox, :append_allowed_tools,
+                  :thinking, :effort, :observers, :task_budget
+    attr_reader :bare, :fork_session, :enable_file_checkpointing,
+                :include_partial_messages, :continue_conversation
 
     def initialize(attributes = {})
       self.fork_session = false

--- a/spec/unit/types_spec.rb
+++ b/spec/unit/types_spec.rb
@@ -1894,7 +1894,7 @@ RSpec.describe ClaudeAgentSDK do
 
     describe ClaudeAgentSDK::PermissionDeniedHookSpecificOutput do
       it 'converts to CLI format' do
-        output = described_class.new(retry_: true)
+        output = described_class.new(retry: true)
         hash = output.to_h
         expect(hash[:hookEventName]).to eq('PermissionDenied')
         expect(hash[:retry]).to eq(true)

--- a/spec/unit/types_spec.rb
+++ b/spec/unit/types_spec.rb
@@ -1921,7 +1921,7 @@ RSpec.describe ClaudeAgentSDK do
 
     describe ClaudeAgentSDK::PermissionDeniedHookSpecificOutput do
       it 'converts to CLI format' do
-        output = described_class.new(retry_: true)
+        output = described_class.new(retry: true)
         hash = output.to_h
         expect(hash[:hookEventName]).to eq('PermissionDenied')
         expect(hash[:retry]).to eq(true)

--- a/spec/unit/types_spec.rb
+++ b/spec/unit/types_spec.rb
@@ -11,6 +11,25 @@ RSpec.describe ClaudeAgentSDK do
   end
 
   describe 'Type Classes' do
+    describe ClaudeAgentSDK::Type do
+      describe '.wrap' do
+        it 'returns the object as-is when already an instance' do
+          block = ClaudeAgentSDK::TextBlock.new(text: 'Hi')
+          expect(ClaudeAgentSDK::TextBlock.wrap(block)).to be(block)
+        end
+
+        it 'constructs a new instance from a hash' do
+          wrapped = ClaudeAgentSDK::TextBlock.wrap(text: 'Hi')
+          expect(wrapped).to be_a(ClaudeAgentSDK::TextBlock)
+          expect(wrapped.text).to eq('Hi')
+        end
+
+        it 'returns nil when given nil' do
+          expect(ClaudeAgentSDK::TextBlock.wrap(nil)).to be_nil
+        end
+      end
+    end
+
     describe ClaudeAgentSDK::TextBlock do
       it 'stores text content' do
         block = described_class.new(text: 'Hello, world!')
@@ -688,6 +707,23 @@ RSpec.describe ClaudeAgentSDK do
 
         expect(new_options.max_turns).to eq(10)
         expect(new_options.model).to eq('claude-opus-4')
+      end
+
+      it 'raises ArgumentError for unknown keys at construction' do
+        expect { described_class.new(modle: 'claude-opus-4') }
+          .to raise_error(ArgumentError, /unknown ClaudeAgentOptions option:.*modle/)
+      end
+
+      it 'raises ArgumentError for unknown keys via dup_with' do
+        options = described_class.new
+        expect { options.dup_with(modle: 'claude-opus-4') }
+          .to raise_error(ArgumentError, /unknown ClaudeAgentOptions option:.*modle/)
+      end
+
+      it 'raises ArgumentError for unknown keys via bracket assignment' do
+        options = described_class.new
+        expect { options[:modle] = 'x' }
+          .to raise_error(ArgumentError, /unknown ClaudeAgentOptions option:.*modle/)
       end
     end
 


### PR DESCRIPTION
## Summary
- Convert remaining types (hook inputs/outputs, MCP configs, `ClaudeAgentOptions`, system prompts, thinking configs, permission results) to inherit from `Type`, centralizing attribute assignment and camelCase normalization
- Mark fixed discriminators (e.g. `type`, `hook_event_name`, `behavior`) as `attr_reader` so they cannot be overwritten externally
- `ClaudeAgentOptions.new` now accepts a hash / `nil` / keyword args, consistent with other `Type` subclasses; unknown keys are silently dropped by `Type#assign_attribute`
- Simplify `MessageParser` system-message dispatch via a `SYSTEM_MESSAGE_CLASSES` lookup table

## Key differences in Type usage

### Construction
| Before | After |
| --- | --- |
| `UserMessage.new(content: x, uuid: u)` — required kwargs per class | `UserMessage.new(content: x, uuid: u)` **or** `UserMessage.new({ 'content' => x, 'uuid' => u })` **or** `UserMessage.new(nil)` |
| String vs symbol keys had to match the ctor signature | Keys may be symbol **or** string, snake_case **or** camelCase (e.g. `sessionId` → `session_id`) |
| Unknown keys raised `ArgumentError` | Unknown keys are silently dropped via `respond_to?(setter)` check |

### Attribute access
| Before | After |
| --- | --- |
| Only `obj.field` / `obj.field = v` | Also `obj[:field]`, `obj['field']`, `obj[:fieldName]` — all normalized through `read_attribute` / `assign_attribute` |
| — | `method_missing` resolves camelCase calls (`obj.sessionId` → `obj.session_id`) |

### Fixed discriminators
| Before | After |
| --- | --- |
| `@type ||= 'file'` with `attr_accessor :type` — externally overridable | `attr_reader :type` + `@type = 'file'` in `initialize` — read-only |

### Factories
- `Type.wrap(obj)` — returns `obj` if already an instance, otherwise `new(obj)`
- `Type.from_hash(hash)` — nil-safe factory, returns `nil` unless `hash.is_a?(Hash)`

### ClaudeAgentOptions specifics
- Previously `def initialize(**kwargs)` with explicit `VALID_OPTIONS` check; now `def initialize(attributes = {})` inheriting Type's hash-based constructor
- `ClaudeAgentOptions.new(nil)` now works (returns an options object populated with `OPTION_DEFAULTS`)
- Default merging with `ClaudeAgentSDK.default_options` is preserved

## Test plan
- [x] `bundle exec rspec` — 611 examples, 0 failures