### PR TITLE
Fix Client#receive_response hang in interactive mode + bump to 0.16.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.4] - 2026-04-23
+
+### Fixed
+- `Client#receive_response` no longer hangs in interactive Client mode. The 0.16.1 flag-based fix relied on the loop draining via the transport's `:end` sentinel, which only arrives when the CLI subprocess exits — true for one-shot `query()` but never for a `Client` whose CLI stays alive between turns. `receive_response` now drives `QueryHandler#receive_messages` directly so its `break` runs on the same fiber as the underlying `Async::Queue#dequeue` loop and unwinds it. The 0.16.1 regression spec passed only because its stub iterated a finite array; replaced with a real `Async::Queue` driven from a sibling task so a hang now fails the test.
+
+### Internal
+- `FiberBoundary` doc-comment now warns that `break`/`return`/`next` cannot cross the thread hop, so SDK-internal loops yielding user callbacks must keep loop control on the outer side of the boundary.
+
 ## [0.16.3] - 2026-04-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Add this line to your application's Gemfile:
 gem 'claude-agent-sdk', github: 'ya-luotao/claude-agent-sdk-ruby'
 
 # Or use a stable version from RubyGems
-gem 'claude-agent-sdk', '~> 0.16.3'
+gem 'claude-agent-sdk', '~> 0.16.4'
 ```
 
 And then execute:

--- a/lib/claude_agent_sdk.rb
+++ b/lib/claude_agent_sdk.rb
@@ -418,15 +418,18 @@ module ClaudeAgentSDK
     def receive_response(&block)
       return enum_for(:receive_response) unless block
 
-      # Flag-based rather than `break`: `receive_messages` hops this
-      # block onto a plain thread via `FiberBoundary.invoke`, which
-      # severs break's unwind target.
-      result_seen = false
-      receive_messages do |message|
-        next if result_seen
+      raise CLIConnectionError, 'Not connected. Call connect() first' unless @connected
 
-        block.call(message)
-        result_seen = true if message.is_a?(ResultMessage)
+      # Keep `break` on the same fiber as the underlying dequeue. Going through
+      # Client#receive_messages would put the FiberBoundary hop above the break
+      # and hang in Client mode — the CLI keeps stdin open and never emits `:end`.
+      @query_handler.receive_messages do |data|
+        message = MessageParser.parse(data)
+        next unless message
+
+        ClaudeAgentSDK.notify_observers(@resolved_observers, :on_message, message)
+        FiberBoundary.invoke { block.call(message) }
+        break if message.is_a?(ResultMessage)
       end
     end
 

--- a/lib/claude_agent_sdk/fiber_boundary.rb
+++ b/lib/claude_agent_sdk/fiber_boundary.rb
@@ -23,6 +23,10 @@ module ClaudeAgentSDK
   # user's app makes.
   #
   # No-op when no scheduler is active, so it's cheap to use unconditionally.
+  #
+  # The thread hop severs `break`/`return`/`next` from the surrounding method,
+  # so SDK loops yielding user callbacks must keep loop control outside the
+  # invoked block (see `Client#receive_response`).
   module FiberBoundary
     module_function
 

--- a/lib/claude_agent_sdk/version.rb
+++ b/lib/claude_agent_sdk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ClaudeAgentSDK
-  VERSION = '0.16.3'
+  VERSION = '0.16.4'
 end

--- a/plugins/claude-agent-ruby/.claude-plugin/plugin.json
+++ b/plugins/claude-agent-ruby/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-agent-ruby",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "description": "Implement or modify Ruby code using the claude-agent-sdk gem. Covers query() one-shot calls, Client-based interactive sessions, streaming input, all 27 hook events, permission callbacks, SDK MCP servers, structured output, bare mode, sandbox settings, session management, Rails integration, and custom transports.",
   "author": {
     "name": "ya-luotao",

--- a/spec/unit/fiber_boundary_spec.rb
+++ b/spec/unit/fiber_boundary_spec.rb
@@ -105,6 +105,54 @@ RSpec.describe 'Fiber scheduler boundary' do
 
       expect(received).to eq([ClaudeAgentSDK::AssistantMessage, ClaudeAgentSDK::ResultMessage])
     end
+
+    # Regression: in Client mode the CLI keeps stdin open after a result, so
+    # `dequeue` blocks indefinitely. `receive_response` must break itself
+    # rather than wait for an `:end` sentinel that never arrives. The
+    # finite-array stub above hides this; a real Async::Queue exposes it.
+    it 'receive_response returns even when the message stream never terminates' do
+      stub_transport
+
+      # Real queue + no `:end` mirrors interactive Client behaviour.
+      queue = Async::Queue.new
+      handler = instance_double(
+        ClaudeAgentSDK::Query,
+        start: true, initialize_protocol: nil,
+        wait_for_result_and_end_input: nil, close: nil
+      )
+      allow(handler).to receive(:receive_messages) do |&block|
+        loop { block.call(queue.dequeue) }
+      end
+      allow(ClaudeAgentSDK::Query).to receive(:new).and_return(handler)
+
+      received = []
+      Async do |task|
+        client = ClaudeAgentSDK::Client.new
+        client.connect
+        begin
+          # Feed from a sibling so the responder unblocks on each dequeue;
+          # if it doesn't break on ResultMessage, the timeout fires.
+          task.async do
+            queue.enqueue(
+              type: 'assistant',
+              message: { role: 'assistant', model: 'claude', content: [{ type: 'text', text: 'hi' }] }
+            )
+            queue.enqueue(
+              type: 'result', subtype: 'success', duration_ms: 1, duration_api_ms: 1,
+              is_error: false, num_turns: 1, session_id: 's', total_cost_usd: 0
+            )
+          end
+
+          task.with_timeout(2.0) do
+            client.receive_response { |msg| received << msg.class }
+          end
+        ensure
+          client.disconnect
+        end
+      end.wait
+
+      expect(received).to eq([ClaudeAgentSDK::AssistantMessage, ClaudeAgentSDK::ResultMessage])
+    end
   end
 
   describe 'SDK MCP tool handler' do


### PR DESCRIPTION
Rebased successor to #29 (which stale-bumped 0.16.1→0.16.2 while main had already advanced to 0.16.3). Same fix, re-targeted at 0.16.4.

## Summary

`Client#receive_response` no longer hangs in interactive Client mode. The 0.16.1 flag-based fix relied on the loop draining via the transport's `:end` sentinel, which only arrives when the CLI subprocess exits — true for one-shot `query()` but never for a `Client` whose CLI stays alive between turns. `receive_response` now drives `QueryHandler#receive_messages` directly so its `break` runs on the same fiber as the underlying `Async::Queue#dequeue` loop and unwinds it.

The 0.16.1 regression spec passed only because its stub iterated a finite array; replaced with a real `Async::Queue` driven from a sibling task so a hang now fails the test.

**Internal:** `FiberBoundary` doc-comment now warns that `break` / `return` / `next` cannot cross the thread hop, so SDK-internal loops yielding user callbacks must keep loop control on the outer side of the boundary.

## Test plan

- [x] `bundle exec rake` — 612 examples, 0 failures; RuboCop clean
- [x] New regression spec in `spec/unit/fiber_boundary_spec.rb` exercises a real `Async::Queue` that never emits `:end`, bounded by a 2s `with_timeout` — a hang fails the test

🤖 Generated with [Claude Code](https://claude.com/claude-code)