### PR TITLE
Add thinking.display option for Opus 4.7 summarized thinking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `display:` option on `ThinkingConfigAdaptive` and `ThinkingConfigEnabled`, forwarded to the CLI as `--thinking-display <summarized|omitted>`. Opus 4.7 defaults thinking display to `"omitted"` (empty `thinking` field, signature only), so pass `ThinkingConfigAdaptive.new(display: "summarized")` to receive plaintext summarized thinking text. Invalid values raise `ArgumentError` at construction. See [adaptive thinking docs](https://docs.claude.com/en/docs/build-with-claude/adaptive-thinking).
+
 ## [0.16.4] - 2026-04-23
 
 ### Fixed

--- a/lib/claude_agent_sdk/command_builder.rb
+++ b/lib/claude_agent_sdk/command_builder.rb
@@ -158,14 +158,25 @@ module ClaudeAgentSDK
         case @options.thinking
         when ThinkingConfigAdaptive
           cmd.push("--thinking", "adaptive")
+          append_thinking_display(cmd, @options.thinking.display)
         when ThinkingConfigEnabled
           cmd.push("--max-thinking-tokens", @options.thinking.budget_tokens.to_s)
+          append_thinking_display(cmd, @options.thinking.display)
         when ThinkingConfigDisabled
           cmd.push("--thinking", "disabled")
         end
       elsif @options.max_thinking_tokens
         cmd.push("--max-thinking-tokens", @options.max_thinking_tokens.to_s)
       end
+    end
+
+    # `--thinking-display` toggles between `"summarized"` (visible thinking
+    # text) and `"omitted"` (empty thinking, signature only). Opus 4.7 defaults
+    # to `"omitted"`, so pass `display: "summarized"` to see reasoning.
+    def append_thinking_display(cmd, display)
+      return if display.nil?
+
+      cmd.push("--thinking-display", display.to_s)
     end
 
     # The set of supported levels is model-dependent; the CLI falls back to

--- a/lib/claude_agent_sdk/types.rb
+++ b/lib/claude_agent_sdk/types.rb
@@ -599,23 +599,53 @@ module ClaudeAgentSDK
   end
 
   # Thinking configuration types
+  #
+  # `display` controls how thinking content appears in responses. Valid values
+  # are `"summarized"` (plaintext summary) and `"omitted"` (empty thinking
+  # field, signature only). Defaults are model-dependent: Opus 4.6/Sonnet 4.6
+  # default to `"summarized"`; Opus 4.7 and Mythos Preview default to
+  # `"omitted"`. Pass `display: "summarized"` explicitly on Opus 4.7 to get
+  # visible thinking text. Not supported with `ThinkingConfigDisabled`.
+  THINKING_DISPLAY_VALUES = %w[summarized omitted].freeze
 
   # Adaptive thinking: uses a default budget of 32000 tokens
   class ThinkingConfigAdaptive
-    attr_accessor :type
+    attr_accessor :type, :display
 
-    def initialize
+    def initialize(display: nil)
       @type = 'adaptive'
+      @display = validate_display(display)
+    end
+
+    private
+
+    def validate_display(value)
+      return nil if value.nil?
+      return value if THINKING_DISPLAY_VALUES.include?(value.to_s)
+
+      raise ArgumentError,
+            "invalid thinking display #{value.inspect}; expected one of #{THINKING_DISPLAY_VALUES.inspect}"
     end
   end
 
   # Enabled thinking: uses a user-specified budget
   class ThinkingConfigEnabled
-    attr_accessor :type, :budget_tokens
+    attr_accessor :type, :budget_tokens, :display
 
-    def initialize(budget_tokens:)
+    def initialize(budget_tokens:, display: nil)
       @type = 'enabled'
       @budget_tokens = budget_tokens
+      @display = validate_display(display)
+    end
+
+    private
+
+    def validate_display(value)
+      return nil if value.nil?
+      return value if THINKING_DISPLAY_VALUES.include?(value.to_s)
+
+      raise ArgumentError,
+            "invalid thinking display #{value.inspect}; expected one of #{THINKING_DISPLAY_VALUES.inspect}"
     end
   end
 

--- a/spec/unit/command_builder_spec.rb
+++ b/spec/unit/command_builder_spec.rb
@@ -182,6 +182,41 @@ RSpec.describe ClaudeAgentSDK::CommandBuilder do
       expect(cmd).to include('--thinking', 'adaptive')
       expect(cmd).not_to include('--max-thinking-tokens')
     end
+
+    it 'passes --thinking-display summarized for adaptive with display' do
+      thinking = ClaudeAgentSDK::ThinkingConfigAdaptive.new(display: 'summarized')
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(thinking: thinking)
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--thinking', 'adaptive')
+      expect(cmd).to include('--thinking-display', 'summarized')
+    end
+
+    it 'passes --thinking-display omitted for adaptive with display' do
+      thinking = ClaudeAgentSDK::ThinkingConfigAdaptive.new(display: 'omitted')
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(thinking: thinking)
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--thinking-display', 'omitted')
+    end
+
+    it 'passes --thinking-display for enabled with display' do
+      thinking = ClaudeAgentSDK::ThinkingConfigEnabled.new(budget_tokens: 5_000, display: 'summarized')
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(thinking: thinking)
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--max-thinking-tokens', '5000')
+      expect(cmd).to include('--thinking-display', 'summarized')
+    end
+
+    it 'omits --thinking-display when display is nil' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(thinking: ClaudeAgentSDK::ThinkingConfigAdaptive.new)
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).not_to include('--thinking-display')
+    end
+
+    it 'raises when display value is invalid' do
+      expect do
+        ClaudeAgentSDK::ThinkingConfigAdaptive.new(display: 'full')
+      end.to raise_error(ArgumentError, /invalid thinking display/)
+    end
   end
 
   describe 'mcp_servers' do

--- a/spec/unit/types_spec.rb
+++ b/spec/unit/types_spec.rb
@@ -1512,6 +1512,22 @@ RSpec.describe ClaudeAgentSDK do
         config = described_class.new
         expect(config.type).to eq('adaptive')
       end
+
+      it 'defaults display to nil' do
+        expect(described_class.new.display).to be_nil
+      end
+
+      it 'accepts display: "summarized"' do
+        expect(described_class.new(display: 'summarized').display).to eq('summarized')
+      end
+
+      it 'accepts display: "omitted"' do
+        expect(described_class.new(display: 'omitted').display).to eq('omitted')
+      end
+
+      it 'rejects unknown display values' do
+        expect { described_class.new(display: 'full') }.to raise_error(ArgumentError, /invalid thinking display/)
+      end
     end
 
     describe ClaudeAgentSDK::ThinkingConfigEnabled do
@@ -1519,6 +1535,17 @@ RSpec.describe ClaudeAgentSDK do
         config = described_class.new(budget_tokens: 16_000)
         expect(config.type).to eq('enabled')
         expect(config.budget_tokens).to eq(16_000)
+      end
+
+      it 'accepts display: "summarized"' do
+        config = described_class.new(budget_tokens: 16_000, display: 'summarized')
+        expect(config.display).to eq('summarized')
+      end
+
+      it 'rejects unknown display values' do
+        expect do
+          described_class.new(budget_tokens: 16_000, display: 'verbose')
+        end.to raise_error(ArgumentError, /invalid thinking display/)
       end
     end
 


### PR DESCRIPTION
## Summary

- Adds `display:` kwarg to `ThinkingConfigAdaptive` and `ThinkingConfigEnabled`
- Forwards it to the CLI as `--thinking-display <summarized|omitted>`
- Restores plaintext thinking text on Opus 4.7, where the API now defaults `display` to `"omitted"` (empty `thinking` field, signature only)

## Why

Opus 4.7 [silently changed the `thinking.display` default](https://docs.claude.com/en/docs/build-with-claude/adaptive-thinking#controlling-thinking-display) from `"summarized"` to `"omitted"`. Callers that used to see reasoning text via `ThinkingBlock#thinking` now get empty strings — the signature is still there, but the plaintext summary is gone unless you explicitly opt in.

Verified with the CLI directly:

```
$ claude -p "..." --model claude-opus-4-7 --thinking adaptive --thinking-display summarized \
    --output-format stream-json --include-partial-messages --verbose
...
"delta":{"type":"thinking_delta","thinking":" I'm breaking down the multiplication..."}
"delta":{"type":"thinking_delta","thinking":" 23 into 20 and 3, multiplying each part..."}
```

The `--thinking-display` flag exists in Claude Code 2.x but is hidden from `--help`. It's in the commander schema inside the compiled binary and is documented at the Messages API level.

## Usage

```ruby
options = ClaudeAgentSDK::ClaudeAgentOptions.new(
  thinking: ClaudeAgentSDK::ThinkingConfigAdaptive.new(display: "summarized")
)
```

Also works with enabled/budgeted thinking:

```ruby
ClaudeAgentSDK::ThinkingConfigEnabled.new(budget_tokens: 16_000, display: "summarized")
```

## Design notes

- `display:` is validated against `%w[summarized omitted]` at construction; bad values raise `ArgumentError` so mistakes surface before a CLI spawn rather than on parse.
- `ThinkingConfigDisabled` intentionally does **not** accept `display` — per the docs, "`display` is invalid with `thinking.type: disabled`".
- Default remains `nil`, meaning "don't emit `--thinking-display` and let the CLI/API pick the model default". This preserves backwards compatibility.

## Test plan

- [x] `bundle exec rspec` — 623 examples, 0 failures
- [x] `bundle exec rubocop` — clean on all touched files
- [x] Live-tested `--thinking adaptive --thinking-display summarized` against `claude-opus-4-7` and confirmed `thinking_delta` events stream with text

Refs:
- Docs: https://docs.claude.com/en/docs/build-with-claude/adaptive-thinking#controlling-thinking-display