### PR TITLE
Add resume_session_at option to forward --resume-session-at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `ClaudeAgentOptions#resume_session_at` — forwarded as `--resume-session-at <message-uuid>` to the CLI. When resuming a session, the conversation is truncated to include only messages up to and including the assistant message with the given UUID, enabling history rewriting / branched continuations from a specific turn. Raises `ArgumentError` from `CommandBuilder` if set without `resume` (matches the CLI's own validation but surfaces it synchronously in the caller's stack).
+
 ## [0.16.6] - 2026-04-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1108,6 +1108,24 @@ result = ClaudeAgentSDK.fork_session(
 
 > **Note:** Session mutations use append-only JSONL writes with `O_WRONLY | O_APPEND` (no `O_CREAT`) for TOCTOU safety. They are safe to call while the session is open in a CLI process. `fork_session` uses `O_CREAT | O_EXCL` to prevent race conditions.
 
+### Resuming at a Specific Message
+
+`resume_session_at` truncates the resumed conversation to messages up to **and including** the assistant message with the given UUID — useful for rewriting history from a known point or branching exploration without forking the session file. The flag rides on top of `resume`, so the original session ID is preserved; only the in-memory history loaded for the new turn is shortened.
+
+```ruby
+ClaudeAgentSDK.query(
+  prompt: 'Try a different approach',
+  options: ClaudeAgentSDK::ClaudeAgentOptions.new(
+    resume: '550e8400-e29b-41d4-a716-446655440000',
+    resume_session_at: 'assistant-message-uuid-from-history'
+  )
+) do |message|
+  # ...
+end
+```
+
+`resume_session_at` requires `resume`; the SDK raises `ArgumentError` from `CommandBuilder` when this constraint is violated, matching the underlying CLI's validation but surfacing it synchronously in the caller's stack.
+
 ## Observability (OpenTelemetry / Langfuse)
 
 The SDK includes a built-in **observer interface** and an **OpenTelemetry observer** for tracing agent sessions. Traces are emitted using standard `gen_ai.*` semantic conventions, compatible with Langfuse, Jaeger, Datadog, and any OTel backend.

--- a/lib/claude_agent_sdk/command_builder.rb
+++ b/lib/claude_agent_sdk/command_builder.rb
@@ -105,7 +105,21 @@ module ClaudeAgentSDK
     def append_session(cmd)
       cmd.push("--continue") if @options.continue_conversation
       cmd.push("--resume", @options.resume) if @options.resume
+      append_resume_session_at(cmd)
       cmd.push("--session-id", @options.session_id) if @options.session_id
+    end
+
+    # `--resume-session-at <message-uuid>` truncates the resumed conversation
+    # to include messages up to and including the given assistant message UUID.
+    # The CLI rejects this flag without `--resume`; we raise early to surface
+    # the misconfiguration in the caller's stack rather than as a remote
+    # process exit.
+    def append_resume_session_at(cmd)
+      return unless @options.resume_session_at
+
+      raise ArgumentError, "resume_session_at requires resume to be set" unless @options.resume
+
+      cmd.push("--resume-session-at", @options.resume_session_at.to_s)
     end
 
     def append_settings(cmd)

--- a/lib/claude_agent_sdk/types.rb
+++ b/lib/claude_agent_sdk/types.rb
@@ -1426,7 +1426,7 @@ module ClaudeAgentSDK
   # Claude Agent Options for configuring queries
   class ClaudeAgentOptions < Type
     attr_accessor :allowed_tools, :system_prompt, :mcp_servers, :permission_mode,
-                  :resume, :session_id, :max_turns, :disallowed_tools,
+                  :resume, :resume_session_at, :session_id, :max_turns, :disallowed_tools,
                   :model, :permission_prompt_tool_name, :cwd, :cli_path, :settings,
                   :add_dirs, :env, :extra_args, :max_buffer_size, :stderr,
                   :can_use_tool, :hooks, :user,

--- a/spec/unit/command_builder_spec.rb
+++ b/spec/unit/command_builder_spec.rb
@@ -144,6 +144,44 @@ RSpec.describe ClaudeAgentSDK::CommandBuilder do
       cmd = described_class.new('/usr/bin/claude', options).build
       expect(cmd).to include('--session-id', 'sess-xyz')
     end
+
+    describe '--resume-session-at' do
+      let(:message_uuid) { 'b3a8f2e6-1c4d-4e9a-9c5d-1f2a3b4c5d6e' }
+
+      it 'passes --resume-session-at alongside --resume' do
+        options = ClaudeAgentSDK::ClaudeAgentOptions.new(
+          resume: 'sess-source',
+          resume_session_at: message_uuid
+        )
+        cmd = described_class.new('/usr/bin/claude', options).build
+        expect(cmd).to include('--resume', 'sess-source')
+        expect(cmd).to include('--resume-session-at', message_uuid)
+      end
+
+      it 'omits --resume-session-at when not set' do
+        options = ClaudeAgentSDK::ClaudeAgentOptions.new(resume: 'sess-source')
+        cmd = described_class.new('/usr/bin/claude', options).build
+        expect(cmd).not_to include('--resume-session-at')
+      end
+
+      it 'raises ArgumentError when used without resume' do
+        options = ClaudeAgentSDK::ClaudeAgentOptions.new(resume_session_at: message_uuid)
+        builder = described_class.new('/usr/bin/claude', options)
+        expect { builder.build }.to raise_error(
+          ArgumentError,
+          /resume_session_at requires resume to be set/
+        )
+      end
+
+      it 'stringifies non-string values' do
+        options = ClaudeAgentSDK::ClaudeAgentOptions.new(
+          resume: 'sess-source',
+          resume_session_at: :"#{message_uuid}"
+        )
+        cmd = described_class.new('/usr/bin/claude', options).build
+        expect(cmd).to include('--resume-session-at', message_uuid)
+      end
+    end
   end
 
   describe 'thinking config' do

--- a/spec/unit/types_spec.rb
+++ b/spec/unit/types_spec.rb
@@ -1541,6 +1541,31 @@ RSpec.describe ClaudeAgentSDK do
         options = ClaudeAgentSDK::ClaudeAgentOptions.new
         expect(options.bare).to be_nil
       end
+
+      it 'accepts resume_session_at option' do
+        uuid = '01234567-89ab-cdef-0123-456789abcdef'
+        options = ClaudeAgentSDK::ClaudeAgentOptions.new(
+          resume: 'sess-1',
+          resume_session_at: uuid
+        )
+        expect(options.resume_session_at).to eq(uuid)
+      end
+
+      it 'defaults resume_session_at to nil' do
+        options = ClaudeAgentSDK::ClaudeAgentOptions.new
+        expect(options.resume_session_at).to be_nil
+      end
+
+      it 'preserves resume_session_at across dup_with' do
+        uuid = '01234567-89ab-cdef-0123-456789abcdef'
+        options = ClaudeAgentSDK::ClaudeAgentOptions.new(
+          resume: 'sess-1',
+          resume_session_at: uuid
+        )
+        duped = options.dup_with(max_turns: 3)
+        expect(duped.resume_session_at).to eq(uuid)
+        expect(duped.max_turns).to eq(3)
+      end
     end
 
     describe ClaudeAgentSDK::ThinkingConfigAdaptive do


### PR DESCRIPTION
## Summary
- Adds `resume_session_at` option to `ClaudeAgentOptions`, forwarded as `--resume-session-at <message-uuid>` to the Claude Code CLI
- When set with `resume`, truncates the resumed conversation to messages up to and including the assistant message with the given UUID — useful for rewriting history or branched continuations from a specific turn without forking the session file
- `CommandBuilder` raises `ArgumentError` if `resume_session_at` is set without `resume`, matching the CLI's own validation but surfacing it synchronously in the caller's stack

## Test plan
- [x] `bundle exec rake` passes (636 examples, 0 failures; RuboCop clean across 41 files)
- [x] New command_builder specs cover: flag is emitted alongside `--resume`, omitted when unset, raises `ArgumentError` when used without `resume`, stringifies non-string values
- [x] New types_spec coverage: option assignment, default `nil`, preservation across `dup_with`
- [ ] Manual smoke test: resume an existing session and pass `resume_session_at` to verify the CLI accepts the flag end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)