### PR TITLE
Fix Symbol#to_s frozen-string warning in Types.normalize_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `Types.normalize_name` no longer mutates the frozen string returned by `Symbol#to_s` under Ruby 3.4+. The previous `name.dup.to_s` order dup'd the Symbol (a no-op) and then took `.to_s`, which Ruby 3.4 stages to return a frozen string in 4.0 — emitting a deprecation warning on every `gsub!`/`tr!`/`downcase!`. Swapped to `name.to_s.dup`.
+
 ## [0.16.8] - 2026-05-15
 
 ### Added

--- a/lib/claude_agent_sdk/types.rb
+++ b/lib/claude_agent_sdk/types.rb
@@ -127,7 +127,7 @@ module ClaudeAgentSDK
     end
 
     def normalize_name(name)
-      name = name.dup.to_s
+      name = name.to_s.dup
       name.gsub!(/(?<=[A-Z])(?=[A-Z][a-z])|(?<=[a-z\d])(?=[A-Z])/, "_")
       name.tr!("-", "_")
       name.downcase!


### PR DESCRIPTION
## Summary
`Types.normalize_name` does `name = name.dup.to_s` and then mutates the result with `gsub!`/`tr!`/`downcase!`. When `name` is a Symbol:

- `Symbol#dup` is a no-op (symbols are immutable singletons), so `.dup.to_s` is equivalent to plain `.to_s` on the original Symbol.
- Ruby 3.4 has staged `Symbol#to_s` to return a frozen string in 4.0, and emits a deprecation warning the moment downstream code mutates it.

Result: every tool registration under Ruby 3.4 emits a warning per attribute (`:name`, `:description`, `:input_schema`, `:handler`, `:annotations`, `:meta`) — roughly six warnings per tool, multiplied by N tools.

Fix is a one-character swap: `name.to_s.dup` instead of `name.dup.to_s`. We coerce to String first, then dup the String so the subsequent in-place mutations operate on storage we own.

All five `normalize_name` call sites in `types.rb` (97, 107, 120, 125, 1552) pass Symbols through this path, so the single change covers everything.

## Test plan
- [x] `ruby -W` smoke test: `ClaudeAgentSDK.create_tool("FooBar", ...)` returns the tool with no deprecation warnings emitted from `types.rb`.
- [x] Soaked under a downstream consumer's full test suite (~3000 Minitest tests on Ruby 3.4.7) — the `:<attr>.to_s will be frozen in the future` warnings previously printed on every test that registered a tool are gone; no regressions.

Drafting until downstream soak has run for at least one more real session.