### PR TITLE
Audit 2026-07-03 Batch A: zero-risk fixes (require shim, guards, coercions)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,3 +41,8 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
     - '*.gemspec'
+
+Naming/FileName:
+  Exclude:
+    # Bundler autorequire shim — the dash name IS the point (matches the gem name).
+    - 'lib/claude-agent-sdk.rb'

--- a/AUDIT-2026-07-03.md
+++ b/AUDIT-2026-07-03.md
@@ -1,0 +1,152 @@
+# Full Codebase Audit Report — claude-agent-sdk-ruby v0.19.0
+
+Date: 2026-07-03
+Method: 13-dimension parallel review (recent-diff/0.2.110 port, control protocol, async/concurrency, subprocess transport, command builder, SDK MCP server, SessionStore/batcher, sessions, parser/types, Observer/OTel, API surface & docs, Python parity, test quality) + a completeness-critic round that spawned 4 follow-up dimensions (packaging/require surface, reference store adapters, disk-vs-store summary differential, session-resume deep dive). 121 agents total. Every bug finding was adversarially verified by 2–3 independent refuters (code-trace / offline reproduction / contract lenses); majority-real → CONFIRMED. 44 raw verified findings → **34 distinct confirmed bugs** (4 high, 19 medium, 11 low; 3 near-duplicates merged), 3 split-verdict findings, 4 refuted, 8 endorsed improvements. Nearly every confirmed finding carries an offline reproduction against the real gem code (fake CLI scripts, real Redis/Docker where relevant); the four high-severity items were re-verified by hand in the main loop.
+
+Baseline: 1010 examples all green, RuboCop clean. All findings are report-only — no source changes were made.
+
+---
+
+## 0. Scope Notes
+
+- **Python parity**: the parity finder checked the Python SDK CHANGELOG/source; no unported releases beyond 0.2.110 were flagged. All parity findings below are behavioral divergences in already-ported surface.
+- **Environment housekeeping** (not code bugs): a stray local `.bundle/config` containing `BUNDLE_PATH: ""` broke `bundle exec` entirely (resolved gem paths to `/ruby/3.4.0`); removed during this audit. `.claude/skills/port-python-parity-workspace/` is untracked skill-eval residue from 2026-06-13 — delete or gitignore.
+
+---
+
+## 1. High-Severity Bugs (4)
+
+### H1. Gem name has no matching main file → `Bundler.require` silently skips the SDK; NameError at first use in every default Rails/Bundler app
+`claude-agent-sdk.gemspec:6` (gem name) vs `lib/` (only `claude_agent_sdk.rb`)
+
+Bundler's autorequire tries `require 'claude-agent-sdk'` (LoadError), then the dash-to-slash fallback `require 'claude/agent/sdk'` (LoadError) — and **swallows the second LoadError by design** (`bundler/runtime.rb`: `raise if e.path != namespaced_file`). `Bundler.require` returns successfully with `ClaudeAgentSDK` undefined. Verified by hand in the main loop against Bundler 2.6.7: after `Bundler.require`, `ClaudeAgentSDK.query` → NameError (in a path-sourced test the constant *appears* defined because gemspec evaluation loads `version.rb` — an empty module shell, which makes the failure extra confusing). README's `gem 'claude-agent-sdk'` instruction hits this in every app relying on Bundler autorequire (i.e. all default Rails apps).
+Fix (zero risk): ship `lib/claude-agent-sdk.rb` containing `# frozen_string_literal: true` + `require 'claude_agent_sdk'` — the standard shim (rails, sidekiq, etc.).
+
+### H2. Signal-terminated CLI is reported as clean success — truncated responses with no error
+`lib/claude_agent_sdk/subprocess_cli_transport.rb:552-567`
+
+`returncode = status&.exitstatus` is `nil` when the process died from a signal (`signaled?` true, `termsig` set — OOM-kill SIGKILL, SIGSEGV…), so `if returncode && returncode != 0` is false, no ProcessError is raised, and the consumer sees a normal end-of-stream with a **truncated** response. `grep` confirms nothing in lib/ consults `signaled?`/`termsig`. Python raises (negative returncode). Reproduced by three verifiers with fake CLIs that SIGKILL themselves mid-stream.
+Fix: when `status&.signaled?`, raise `ProcessError("Command terminated by signal #{status.termsig}", exit_code: nil/negative, stderr: ...)` — mirrors Python.
+
+### H3. Empty-string metadata poisons `build_session_info`'s `||` chains — session silently vanishes from all disk read paths
+`lib/claude_agent_sdk/sessions.rb:311-324` (same root cause reported independently at :320)
+
+Ported from Python `or` (falsy `""`) to Ruby `||` (truthy `""`). A trailing `{"type":"custom-title","customTitle":""}` (CLI clearing a title) makes `custom_title = ""` win over a real first prompt; then `return nil if summary.strip.empty?` drops the **entire session** from `list_sessions`/`get_session_info`. The store path (`SessionSummary.presence`) and Python both fall through correctly — a direct violation of the documented two-paths-agree contract (sessions.rb:520-521). Whitespace-only titles have the same effect.
+Fix: filter through a `presence` helper (empty/whitespace → nil) before the `||` chains, exactly like `SessionSummary.presence`.
+
+### H4. String mtimes from a SessionStore adapter make `--continue` silently resume the OLDEST session
+`lib/claude_agent_sdk/session_resume.rb:154`
+
+`sessions.sort_by { |s| -(s['mtime'] || 0) }` — unary minus on a String is `String#-@` (frozen-string dedup, returns the string), so ISO-8601 mtimes (the natural SQL-timestamp-through-JSON shape) sort lexicographically **ascending**; `continue_conversation: true` resumes the oldest conversation with no error. Mixed Integer/String mtimes raise a bare `ArgumentError` outside `with_timeout`'s wrapper. One of three verifiers voted "contract says mtime is epoch-ms Integer, so the adapter is at fault" — fair, but the failure is silent-wrong-session, the conformance suite doesn't enforce the type, and the fix is one line.
+Fix: coerce/guard (`Integer === s['mtime'] ? s['mtime'] : s['mtime'].to_i` or validate + warn), and add an mtime-type contract to the conformance suite.
+
+---
+
+## 2. Medium-Severity Bugs (19)
+
+### Control protocol / concurrency
+
+**M1. `@inflight_control_request_tasks` leaks a finished task for every synchronously-handled control request.** `query.rb:252-259`. The handler task's `ensure` deletes its map entry *before* the read loop inserts it (async runs non-suspending children to completion inside `parent.async{}`); MCP metadata handlers (initialize / tools_list / resources_list / prompts_list / notifications-initialized) and the unknown-subtype error path never suspend, so every such request inserts an already-finished task nothing removes. Unbounded (slow) growth in long-lived Clients with SDK MCP servers; reproduced (6 requests → 6 permanent entries). Fix: `@inflight_control_request_tasks[request_id] = handler_task unless handler_task.finished?`.
+
+**M2. `Query#close` crashes with NoMethodError when called from a FiberBoundary worker thread.** `query.rb:1166-1168`. `Async::Task#stop` needs `Fiber.scheduler` (per-thread, nil on plain threads). Any tool handler / hook / permission callback that calls `client.disconnect` — a natural "session done, shut down" pattern — hits `Fiber.scheduler.raise` → `NoMethodError` on nil, leaving read/child tasks un-stopped. Reproduced. Fix: detect the missing scheduler in `close` and marshal the stop onto the reactor (e.g. via the control queue / a scheduled task), or no-op the task-stops with the transport-close path handling shutdown.
+
+**M3. Invalid UTF-8 byte on one stdout line kills the whole stream.** `subprocess_cli_transport.rb:507`. `line.strip` raises `Encoding::CompatibilityError`/`ArgumentError` on invalid bytes; the loop's rescue only covers IOError/StopIteration, so buffered valid messages (including a trailing `result`) are lost. The version-probe path already guards with `.force_encoding(UTF_8).scrub` (inconsistent). Fix: scrub each line before strip, as the probe does.
+
+**M4. In-flight mirror-drain failure at end-of-stream enqueues MirrorErrorMessage *after* the `'end'` sentinel — never delivered.** `transcript_mirror_batcher.rb:130-137` + `query.rb:1140`. Violates the documented "failures surface as MirrorErrorMessage" guarantee for the last flush of a turn in eager mode. Reproduced with real Query + real batcher. Fix: report errors before releasing the flush barrier, or have `flush_transcript_mirror` drain pending error reports before `'end'` is enqueued.
+
+### API surface
+
+**M5. StopIteration from a user message block is swallowed by `Kernel#loop`.** `query.rb:1138-1144`. `loop` rescues StopIteration → reception ends early, ResultMessage dropped, `receive_response`/`query()` return as if complete, `on_error` never fires. A block calling `.next` on an exhausted Enumerator triggers it. Fix: replace `loop do` with `while true` in `receive_messages` (behavior for genuine queue-end is unchanged).
+
+**M6. Top-level `query()` doesn't validate prompt type.** `claude_agent_sdk.rb:452-466`. A bare Hash prompt (respond_to?(:each)) streams `[:type, "user"]`-style `to_s` garbage to the CLI; nil/Integer hangs forever. `Client#query` already raises ArgumentError for exactly this. Fix: port the Client guard to `query()`.
+
+**M7. `exclude_dynamic_sections` is silently dropped in one-shot `query()`.** `claude_agent_sdk.rb:422-430`. Query is built without the kwarg, so `excludeDynamicSections` never reaches the initialize request; Client and Python both send it. Fix: pass the extracted value like `connect_inner` does.
+
+**M8. `dup_with` is a shallow copy — derived options share nested containers.** `types.rb:1587-1591`. `full.allowed_tools << 'Bash'` mutates the base and every sibling variant — including the security-relevant allow/deny lists — contradicting the documented "immutable-style updates". `merge_with_defaults` already deep-dups with a comment naming this exact hazard. Fix: reuse `deep_dup_containers` inside `dup_with`.
+
+### Packaging / docs-as-shipped
+
+**M9. `require 'claude_agent_sdk/instrumentation'` does not load the SDK core.** `instrumentation.rb:6`. The docs/rails.md initializer (its only require) and otel.rb's own `@example` crash with NoMethodError/NameError — compounding H1, since Bundler autorequire loaded nothing. Fix: `require_relative '../claude_agent_sdk'` at the top of instrumentation.rb.
+
+### Sessions / resume / store
+
+**M10. `fork_session` hangs forever on a progress-entry parentUuid cycle.** `session_mutations.rb:527-536`. `resolve_parent_uuid` is the only chain-walker in the codebase without a visited-set guard; invoked per written entry on both fork paths. Reproduced (5s timeout trips). Fix: add the same `Set` guard as `walk_to_leaf`/`walk_to_root`.
+
+**M11. `fork_session`/`delete_session` stop at a 0-byte stub.** `session_mutations.rb:283-288`. `try_project_dir` accepts on `File.exist?` alone while the read/append paths explicitly skip 0-byte stubs to fall through to worktree project dirs. delete removes the stub leaving the real transcript; fork raises "has no messages to fork". Fix: add the zero-byte guard to `try_project_dir`.
+
+**M12. `extract_first_prompt_from_head` dropped Python's shape guards — one malformed head line silently drops the whole session from disk listings.** `sessions.rb:250-262`. Non-string `text` / string `message` → NoMethodError/TypeError → `read_session_lite`'s blanket rescue → nil. Store fold and Python skip just the bad block. Fix: port the three `is_a?` guards.
+
+**M13. `extract_first_prompt_from_head` never rechecks `entry['type']=='user'` after parsing.** `sessions.rb:244-256`. An assistant line whose tool_use input contains `"type":"user"` passes the byte pre-filter and its assistant text becomes first_prompt/summary. Python rechecks. Fix: `next unless entry['type'] == 'user'` after parse.
+
+**M14. Disk tail byte-scan matches summary/customTitle/lastPrompt keys nested inside tool_use inputs.** `sessions.rb:311-323` + `extract_json_string_field`. Real transcripts (teammate SendMessage inputs) contain nested unescaped `"summary":"..."`; when the last match is nested and the true entry fell outside the 64KB window, disk summary/custom_title report tool-argument text; the store fold reads only top-level keys. Fix direction: after a byte match, JSON-parse the single containing line and read the top-level key (bounded cost), or accept + document the divergence.
+
+**M15. `copy_auth_files` calls `Dir.home` unconditionally — resume-from-store crashes in HOME-less containers even with API-key auth.** `session_resume.rb:202,218`. `Dir.home` raises ArgumentError with no HOME and no passwd entry (arbitrary-UID containers); the API-key guard only protects the Keychain read. Reproduced in real containers (ruby:3.3/3.4-slim, uid without passwd). Fix: wrap in `begin/rescue ArgumentError` (or check `ENV['HOME']`) and skip copying — matching the "missing files are fine" comment.
+
+**M16. Materialized-resume cleanup deletes the only transcript copy when the store mirror failed.** `session_resume.rb:28` + `claude_agent_sdk.rb:871-875`. In resume-from-store, the CLI's authoritative transcript lives in the temp CLAUDE_CONFIG_DIR; mirror failures never raise (by design) but drop batches; disconnect's `cleanup` then rmtree's the only copy of those turns — permanent loss. Fix: on any dropped batch (batcher already knows), skip/defer the rmtree with a warning pointing at the preserved path, or attempt a final salvage import before cleanup.
+
+### Command building / MCP
+
+**M17. Typed MCP server config objects serialize as `#<...>` garbage.** `command_builder.rb:309-313` + `claude_agent_sdk.rb:397,909`. `McpStdioServerConfig`/`McpSSEServerConfig`/`McpHttpServerConfig` passed directly (without `.to_h`) produce an unparseable `--mcp-config`; `McpSdkServerConfig` is doubly broken — the `is_a?(Hash)` guard means the live server instance is never registered, so in-process tools silently never connect. Fix: `config = config.to_h if config.respond_to?(:to_h) && !config.is_a?(Hash)` in both places.
+
+### Reference adapters / conformance (shipped examples & testing lib)
+
+**M18. Conformance suite loophole: one-row-per-append `list_sessions` passes all 15 contracts.** `testing/session_store_conformance.rb:104-136`. No contract calls `list_sessions` after multiple appends to one session (the one that does collapses dupes via `.to_h`); the suite's own comment names this failure mode but guards only `list_session_summaries`. The naive SQL adapter ships green, then session pickers show N duplicates. Fix: add a contract — 3 appends to one session → `list_sessions` returns exactly 1 row.
+
+**M19. Reference-adapter hazards (examples/, spec/examples/):** (a) `spec/examples/redis_session_store_spec.rb:33` runs **FLUSHDB** 15+ times against whatever `SESSION_STORE_REDIS_URL` points at — the README invites pointing it at real infrastructure; the sibling Postgres spec already shows the safe pattern (random-suffixed namespace, scoped cleanup). Reproduced against a seeded throwaway Redis: unrelated keys wiped. (b) `postgres_session_store.rb:47` documents "a single PG::Connection suffices" — but appends run on fresh FiberBoundary threads and pg explicitly forbids cross-thread simultaneous access; two concurrent sessions sharing the documented setup → `PG::UnableToSend`/protocol desync. Fix: (a) random key prefix + prefix-scoped cleanup; (b) fix the comment/README to require a per-call connection or connection pool, or add an internal mutex.
+
+---
+
+## 3. Low-Severity Issues (11)
+
+- **L1.** `command_builder.rb:183` — `sandbox: true` (plausible boolean toggle; Python emits `{"sandbox": true}`) crashes with `NoMethodError: undefined method 'empty?' for true`. Raise a clear ArgumentError or accept the boolean.
+- **L2.** `command_builder.rb:285-297` — `output_format {type:'json_schema'}` with nil/absent schema emits `--json-schema null` (CLI rejects); any non-json_schema hash is forwarded wholesale as the schema. Python guards `schema is not None`. Skip the flag when schema is nil.
+- **L3.** `command_builder.rb:171` — missing settings file + sandbox raises CLIConnectionError; Python warns and continues with sandbox-only settings. Parity decision needed (warn+continue matches Python).
+- **L4.** `sdk_mcp_server.rb:473` — `create_tool(:add, ...)` with a Symbol name is advertised (Symbol serializes fine in tools/list) but every tools/call misses the Symbol-keyed hash → 'Tool not found'. Fix: `name.to_s` at creation.
+- **L5.** `message_parser.rb:39` — the `rescue KeyError` is dead code (no `fetch` anywhere); meanwhile non-Hash `message` fields raise raw TypeError instead of the documented MessageParseError. Wrap with a Hash guard.
+- **L6.** `instrumentation/otel.rb:57-63` — after a superseding init with no ResultMessage (/clear, interrupted turn), the next turn's prompt is dropped from the new trace (`@first_user_input` latch cleared only *after* the new prompt arrived). Buffer per-turn instead of latch-first.
+- **L7.** `claude_agent_sdk.rb:471` vs `:957-959` — a raising initial-Enumerator prompt fires observer `on_error` under `Client#connect` but not under `query()`; observer.rb documents "not notified". Align (drop the `error_notifying_stream` wrap on the initial prompt, or fix the doc).
+- **L8.** `examples/session_stores/redis_session_store.rb:118` — delete cascade SMEMBERS outside the MULTI (no WATCH/Lua); a concurrent eager-mode append orphans a freshly-created subagent list forever (README recommends noeviction). Use WATCH or re-check the set post-MULTI.
+- **L9.** `sessions.rb:289-290` — sidechain classification by raw substring on the first line; nested `"isSidechain":true` in a structured field hides the session from disk listings only. Parse the first line instead.
+- **L10.** `spec/integration/query_spec.rb` — the RUN_INTEGRATION suite contains zero integration (tautological `respond_to` checks); real CLI specs gate additionally on RUN_REAL_INTEGRATION, so CLAUDE.md's documented release check runs no CLI test. Delete tautologies; unify the gates (make RUN_INTEGRATION run the real suite, keeping its skip-if-no-CLI guards).
+- **L11.** `spec/unit/transport_spec.rb:45-99` — 10 of 14 examples assert against a fixture class defined in the spec itself; they cannot fail under any SDK change. Replace with real-contract assertions (e.g. SubprocessCLITransport conforms to the six-method interface).
+
+---
+
+## 4. Split-Verdict Findings (3) — recorded, not confirmed
+
+- **P1.** `sdk_mcp_server.rb:37` — object schemas without `properties` (additionalProperties/oneOf/$ref forms) are mangled by `normalize_tool_schema` into nonsense parameter lists (1 real / 1 refuted: mcp-gem behavior differences muddy the impact). Worth a look when touching schema handling.
+- **P2.** `sessions.rb:888` — `import_session_to_store` has no per-line rescue: a truncated final line (ordinary interrupted-CLI artifact) aborts mid-import, leaving a partial store import + raw JSON::ParserError (1/3 real: refuters argued fail-fast on corrupt import input is defensible; the asymmetry with every read path remains). Cheap hardening: tolerate trailing corrupt lines like `parse_jsonl_entries` does.
+- **P3.** `examples/session_stores/*` — none of the three reference adapters dedupe by `entry['uuid']` despite the contract's "should dedupe" and retry-overlap reality (1/3 real: refuters noted "should" is advisory and duplicate text mostly self-heals via last-wins folds; resume paths can still duplicate turns). Consider making the conformance suite exercise a retried batch.
+
+## Refuted findings for the record (4): observer-concurrency race (FiberBoundary serializes), MCP handler-error prefix parity, shared-OTelObserver corruption (factory pattern documented), tag-line key-reorder round-trip (unreachable through real store writers).
+
+---
+
+## 5. Endorsed Improvements (8, all small)
+
+1. **`message_parser.rb:71`** — require `message.model` on assistant messages (raise MessageParseError like Python) instead of silently constructing `model: nil`.
+2. **`session_store_conformance.rb:89`** — add the missing phantom-key contract: `append(fresh_key, [])` then `load == nil` and absent from listings (documented on InMemorySessionStore but never asserted).
+3. **`claude_agent_sdk.rb:31`** — `observers: [OTelObserver]` (a Class, not an instance) currently yields silent zero instrumentation (NoMethodError swallowed per-notify). Add a capability check in `resolve_observers` that warns/raises.
+4. **`query.rb:832-846`** — zero spec coverage for either ControlRequestTimeoutError path (reactor and worker-thread deadline loop). Add two specs.
+5. **`claude-agent-sdk.gemspec:24`** — `spec.files` is a working-tree `Dir` glob: untracked files under lib//docs/ ship in locally built gems. Switch to a git-ls-files-based list (verified byte-identical on a clean tree).
+6. **`docs/sessions.md:169` et al.** — packaged docs/README link relatively to `examples/`/`assets/` which are excluded from the gem (dead links on rubydoc.info and in installed gems, ~25 links). Use absolute GitHub URLs pinned to a tag, or package examples/.
+7. **`examples/session_stores/postgres_session_store.rb:107` (+ Redis)** — stamp mtime with a monotonic guard like the S3 adapter (or from the DB), so a backward clock step can't misdirect `--continue`.
+8. **`session_resume.rb:158`** — `--continue` downloads every sidechain candidate's full transcript just to read `entries[0]`; use `list_session_summaries` (when implemented) or a head-only load to make it O(candidates).
+
+---
+
+## 6. Suggested Fix Priorities
+
+**Batch A — zero-risk, ship immediately** (pure additions / guards; no behavior change for valid inputs):
+H1 shim file · M9 instrumentation require · M10 cycle guard · M11 zero-byte guard · M17 `.to_h` coercion · L4 `name.to_s` · M1 finished-task guard · M3 line scrub · I2/I3/I4 (observer guard, timeout specs, gemspec files)
+
+**Batch B — behavioral fixes aligning code with documented contracts / Python** (each needs a spec):
+H2 signal exit · H3 presence chains · H4 mtime coercion (+ conformance contract) · M5 `while true` · M6 prompt validation · M7 exclude_dynamic_sections · M8 deep-dup · M12/M13 head guards · L1/L2 builder guards · L5 MessageParseError wrap · I1 model requiredness
+
+**Batch C — design decisions needed before fixing**:
+M2 (close-from-callback marshaling) · M4 (mirror-error ordering) · M14 (nested-key scan strategy) · M16 (cleanup-on-mirror-failure policy) · L3/L7 (parity/doc alignment) · M19b (adapter connection guidance)
+
+**Batch D — tests/docs/examples only**:
+M18/M19a · L6 · L8-L11 · I0 candidates · improvements 5-8
+
+Every batch preserves existing green tests; Batch B items change behavior only for inputs that today produce wrong results, hangs, or crashes.

--- a/claude-agent-sdk.gemspec
+++ b/claude-agent-sdk.gemspec
@@ -20,8 +20,17 @@ Gem::Specification.new do |spec|
   spec.metadata['documentation_uri'] = 'https://rubydoc.info/gems/claude-agent-sdk'
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 
-  # Specify which files should be added to the gem when it is released.
-  spec.files = Dir['lib/**/*', 'docs/**/*', 'README.md', 'LICENSE', 'CHANGELOG.md']
+  # Ship only git-tracked files: a working-tree Dir glob would package any
+  # stray/untracked files under lib/ or docs/ present at build time (a stray
+  # lib/*.rb even becomes requireable code in the released gem). Fall back to
+  # the glob when git is unavailable (e.g. building from a source tarball).
+  tracked = begin
+    IO.popen(%w[git ls-files -z lib docs README.md LICENSE CHANGELOG.md],
+             chdir: __dir__, err: File::NULL, &:read).split("\x0")
+  rescue SystemCallError
+    []
+  end
+  spec.files = tracked.empty? ? Dir['lib/**/*', 'docs/**/*', 'README.md', 'LICENSE', 'CHANGELOG.md'] : tracked
   spec.require_paths = ['lib']
 
   # Runtime dependencies

--- a/lib/claude-agent-sdk.rb
+++ b/lib/claude-agent-sdk.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Bundler autorequire shim. The gem is named `claude-agent-sdk`, so
+# `Bundler.require` tries `require 'claude-agent-sdk'` and then
+# `require 'claude/agent/sdk'` — and silently swallows both LoadErrors when
+# neither file exists, leaving the SDK unloaded in default Rails/Bundler
+# apps. This file makes the gem-named require resolve to the real entry point.
+require_relative 'claude_agent_sdk'

--- a/lib/claude_agent_sdk.rb
+++ b/lib/claude_agent_sdk.rb
@@ -32,6 +32,21 @@ module ClaudeAgentSDK
     end
   end
 
+  # Internal: pull live SDK MCP server instances out of an mcp_servers Hash.
+  # Accepts both raw Hash configs and typed Mcp*ServerConfig objects — a
+  # McpSdkServerConfig passed without .to_h previously failed the Hash-only
+  # guard, so its in-process server was silently never registered.
+  def self.extract_sdk_mcp_servers(mcp_servers)
+    return {} unless mcp_servers.is_a?(Hash)
+
+    servers = {}
+    mcp_servers.each do |name, config|
+      config = config.to_h if config.is_a?(Type)
+      servers[name] = config[:instance] if config.is_a?(Hash) && config[:type] == 'sdk'
+    end
+    servers
+  end
+
   # Safely call a method on each observer, suppressing any errors.
   # Each observer is invoked through FiberBoundary so that user code runs
   # on a plain thread (no Fiber scheduler) even when called from inside
@@ -391,12 +406,7 @@ module ClaudeAgentSDK
         transport.connect
 
         # Extract SDK MCP servers
-        sdk_mcp_servers = {}
-        if configured_options.mcp_servers.is_a?(Hash)
-          configured_options.mcp_servers.each do |name, config|
-            sdk_mcp_servers[name] = config[:instance] if config.is_a?(Hash) && config[:type] == 'sdk'
-          end
-        end
+        sdk_mcp_servers = extract_sdk_mcp_servers(configured_options.mcp_servers)
 
         hooks = nil
         if configured_options.hooks
@@ -903,12 +913,7 @@ module ClaudeAgentSDK
       @transport.connect
 
       # Extract SDK MCP servers
-      sdk_mcp_servers = {}
-      if configured_options.mcp_servers.is_a?(Hash)
-        configured_options.mcp_servers.each do |name, config|
-          sdk_mcp_servers[name] = config[:instance] if config.is_a?(Hash) && config[:type] == 'sdk'
-        end
-      end
+      sdk_mcp_servers = ClaudeAgentSDK.extract_sdk_mcp_servers(configured_options.mcp_servers)
 
       # Convert hooks to internal format
       hooks = convert_hooks_to_internal_format(configured_options.hooks) if configured_options.hooks

--- a/lib/claude_agent_sdk.rb
+++ b/lib/claude_agent_sdk.rb
@@ -23,12 +23,27 @@ require 'securerandom'
 
 # Claude Agent SDK for Ruby
 module ClaudeAgentSDK
+  # The duck-typed observer surface probed by resolve_observers — implementing
+  # any one of these counts as an observer (see Observer's no-op defaults).
+  OBSERVER_INTERFACE = %i[on_user_prompt on_message on_error on_close].freeze
+
   # Resolve observers array: callables (Proc/lambda) are invoked to produce
   # a fresh instance per query/session (thread-safe); plain objects are used as-is.
   # Array() guards against nil (e.g., when observers: nil is passed explicitly).
+  # Anything implementing none of the observer methods is warned about and
+  # skipped — most commonly a Class passed instead of an instance, which
+  # previously produced silent zero instrumentation (every notify raised
+  # NoMethodError, swallowed by notify_observers' error containment).
   def self.resolve_observers(observers)
-    Array(observers).map do |obs|
-      obs.respond_to?(:call) ? obs.call : obs
+    Array(observers).filter_map do |obs|
+      resolved = obs.respond_to?(:call) ? obs.call : obs
+      if OBSERVER_INTERFACE.none? { |m| resolved.respond_to?(m) }
+        label = resolved.is_a?(Module) ? resolved : resolved.class
+        hint = resolved.is_a?(Module) ? " — pass an instance (#{resolved}.new) or a factory lambda" : ''
+        warn "ClaudeAgentSDK: ignoring observer #{label}: it implements none of #{OBSERVER_INTERFACE.join('/')}#{hint}"
+        next nil
+      end
+      resolved
     end
   end
 

--- a/lib/claude_agent_sdk/command_builder.rb
+++ b/lib/claude_agent_sdk/command_builder.rb
@@ -306,6 +306,9 @@ module ClaudeAgentSDK
       if @options.mcp_servers.is_a?(Hash)
         servers_for_cli = {}
         @options.mcp_servers.each do |name, config|
+          # Typed Mcp*ServerConfig objects serialize via their wire hash —
+          # without this they'd JSON-stringify as "#<...>" via to_s.
+          config = config.to_h if config.is_a?(Type)
           servers_for_cli[name] = if config.is_a?(Hash) && config[:type] == "sdk"
                                     config.except(:instance)
                                   else

--- a/lib/claude_agent_sdk/instrumentation.rb
+++ b/lib/claude_agent_sdk/instrumentation.rb
@@ -3,4 +3,10 @@
 # Instrumentation adapters for ClaudeAgentSDK.
 # Each adapter lazy-requires its external gem, so loading this file has zero cost
 # unless you instantiate a specific observer.
+#
+# This entry point is documented as a standalone require (docs/rails.md's
+# initializer, OTelObserver's @example), so it must load the SDK core too —
+# otherwise ClaudeAgentSDK exists (observer.rb reopens the module) but has
+# no .configure/.query/ClaudeAgentOptions.
+require_relative '../claude_agent_sdk'
 require_relative 'instrumentation/otel'

--- a/lib/claude_agent_sdk/query.rb
+++ b/lib/claude_agent_sdk/query.rb
@@ -256,7 +256,11 @@ module ClaudeAgentSDK
               @inflight_control_request_tasks.delete(request_id) if request_id
             end
           end
-          @inflight_control_request_tasks[request_id] = handler_task if request_id
+          # A handler that never suspends (MCP metadata, unsupported-subtype
+          # error path) already ran to completion inside the async{} above —
+          # its ensure-delete fired before this insert, so registering it here
+          # would leak a finished task in the map forever.
+          @inflight_control_request_tasks[request_id] = handler_task if request_id && !handler_task.finished?
         when 'control_cancel_request'
           request_id = message[:request_id] || message[:requestId]
           task = request_id ? @inflight_control_request_tasks[request_id] : nil

--- a/lib/claude_agent_sdk/sdk_mcp_server.rb
+++ b/lib/claude_agent_sdk/sdk_mcp_server.rb
@@ -470,6 +470,11 @@ module ClaudeAgentSDK
       resolved_meta = { 'anthropic/maxResultSizeChars' => max_chars } if max_chars
     end
 
+    # tools/call arrives from the CLI with the name as a JSON String; the mcp
+    # gem keys its lookup on the value stored here, so a Symbol name would be
+    # advertised in tools/list yet miss on every invocation ('Tool not found').
+    name = name.to_s if name.is_a?(Symbol)
+
     SdkMcpTool.new(
       name: name,
       description: description,

--- a/lib/claude_agent_sdk/session_mutations.rb
+++ b/lib/claude_agent_sdk/session_mutations.rb
@@ -280,11 +280,17 @@ module ClaudeAgentSDK
       nil
     end
 
+    # A candidate counts only when it exists AND is non-empty — a 0-byte stub
+    # in one project dir must not stop the search when the real transcript
+    # lives under another (worktree) project dir. Mirrors the read path
+    # (Sessions.stat_candidate) and the append path (try_append).
     def try_project_dir(file_name, project_dir)
       return nil unless project_dir
 
       candidate = File.join(project_dir, file_name)
-      File.exist?(candidate) ? [candidate, project_dir] : nil
+      File.size(candidate).positive? ? [candidate, project_dir] : nil
+    rescue SystemCallError
+      nil
     end
 
     def find_in_all_projects(file_name)
@@ -295,8 +301,8 @@ module ClaudeAgentSDK
         pd = File.join(projects_dir, child)
         next unless File.directory?(pd)
 
-        candidate = File.join(pd, file_name)
-        return [candidate, pd] if File.exist?(candidate)
+        result = try_project_dir(file_name, pd)
+        return result if result
       end
       nil
     end

--- a/lib/claude_agent_sdk/session_mutations.rb
+++ b/lib/claude_agent_sdk/session_mutations.rb
@@ -523,9 +523,13 @@ module ClaudeAgentSDK
       JSON.generate(forked)
     end
 
-    # Walk up parentUuid chain skipping progress entries.
+    # Walk up parentUuid chain skipping progress entries. The visited set
+    # guards against parentUuid cycles among progress entries (corrupt
+    # transcripts) like every other chain walker — an unguarded walk spun
+    # forever and hung both fork paths.
     def resolve_parent_uuid(parent_id, by_uuid, uuid_mapping)
-      while parent_id
+      visited = Set.new
+      while parent_id && visited.add?(parent_id)
         parent = by_uuid[parent_id]
         break unless parent
         return uuid_mapping[parent_id] if parent['type'] != 'progress'

--- a/lib/claude_agent_sdk/subprocess_cli_transport.rb
+++ b/lib/claude_agent_sdk/subprocess_cli_transport.rb
@@ -494,6 +494,13 @@ module ClaudeAgentSDK
         # an oversized line was fully allocated BEFORE the 1MB cap could
         # fire — unbounded memory on hostile/buggy stdout.
         @stdout.each_line("\n", @max_buffer_size + 1) do |line|
+          # stdout is UTF-8-tagged but the CLI can emit invalid bytes (echoed
+          # binary/latin-1 output). strip/lstrip below raise on invalid
+          # encoding, which would abort the whole stream and drop buffered
+          # valid frames — scrub the one bad line instead (the version-probe
+          # path guards the same way).
+          line = line.scrub unless line.valid_encoding?
+
           # Position-aware whitespace handling: a chunk of an over-limit line
           # must keep its interior whitespace — a blanket per-chunk strip
           # deleted spaces inside JSON strings straddling the chunk boundary

--- a/spec/unit/command_builder_spec.rb
+++ b/spec/unit/command_builder_spec.rb
@@ -356,6 +356,30 @@ RSpec.describe ClaudeAgentSDK::CommandBuilder do
       idx = cmd.index('--mcp-config')
       expect(cmd[idx + 1]).not_to include('instance')
     end
+
+    it 'serializes typed server config objects via their wire hash' do
+      # A typed config passed without .to_h previously fell through the
+      # Hash-only handling and JSON.generate stringified it as "#<...>".
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(
+        mcp_servers: {
+          'api' => ClaudeAgentSDK::McpHttpServerConfig.new(url: 'https://example.com/mcp', headers: { 'X-Key' => 'v' })
+        }
+      )
+      cmd = described_class.new('/usr/bin/claude', options).build
+      idx = cmd.index('--mcp-config')
+      parsed = JSON.parse(cmd[idx + 1])
+      expect(parsed['mcpServers']['api']).to eq('type' => 'http', 'url' => 'https://example.com/mcp', 'headers' => { 'X-Key' => 'v' })
+    end
+
+    it 'strips :instance from typed McpSdkServerConfig objects' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(
+        mcp_servers: { 'calc' => ClaudeAgentSDK::McpSdkServerConfig.new(name: 'calc', instance: Object.new) }
+      )
+      cmd = described_class.new('/usr/bin/claude', options).build
+      idx = cmd.index('--mcp-config')
+      parsed = JSON.parse(cmd[idx + 1])
+      expect(parsed['mcpServers']['calc']).to eq('type' => 'sdk', 'name' => 'calc')
+    end
   end
 
   describe 'extra_args' do

--- a/spec/unit/observer_spec.rb
+++ b/spec/unit/observer_spec.rb
@@ -183,6 +183,21 @@ RSpec.describe ClaudeAgentSDK::Observer do
     it 'handles nil gracefully' do
       expect(ClaudeAgentSDK.resolve_observers(nil)).to eq([])
     end
+
+    it 'warns and skips a Class passed instead of an instance' do
+      # observers: [OTelObserver] (no .new) previously stored the Class as the
+      # observer; every notify raised NoMethodError, which notify_observers
+      # swallows — silent zero instrumentation with zero surfaced errors.
+      resolved = nil
+      expect { resolved = ClaudeAgentSDK.resolve_observers([observer_class]) }
+        .to output(/instance/).to_stderr
+      expect(resolved).to eq([])
+    end
+
+    it 'keeps duck-typed observers implementing any single observer method' do
+      duck = Class.new { def on_message(_msg); end }.new
+      expect(ClaudeAgentSDK.resolve_observers([duck])).to eq([duck])
+    end
   end
 
   describe 'observer wiring in query()' do

--- a/spec/unit/query_spec.rb
+++ b/spec/unit/query_spec.rb
@@ -1215,6 +1215,45 @@ RSpec.describe ClaudeAgentSDK::Query do
     end
   end
 
+  describe 'control request timeouts' do
+    # Covers both await_control_response paths, previously untested:
+    # the reactor path (Async::TimeoutError -> ControlRequestTimeoutError)
+    # and the worker-thread deadline loop used when a control method is
+    # called from a FiberBoundary callback (no reactor on the thread).
+    around do |example|
+      previous = ENV.fetch(ClaudeAgentSDK::Query::CONTROL_REQUEST_TIMEOUT_ENV_VAR, nil)
+      ENV[ClaudeAgentSDK::Query::CONTROL_REQUEST_TIMEOUT_ENV_VAR] = '0.2'
+      example.run
+    ensure
+      if previous
+        ENV[ClaudeAgentSDK::Query::CONTROL_REQUEST_TIMEOUT_ENV_VAR] = previous
+      else
+        ENV.delete(ClaudeAgentSDK::Query::CONTROL_REQUEST_TIMEOUT_ENV_VAR)
+      end
+    end
+
+    let(:query) do
+      described_class.new(transport: instance_double(ClaudeAgentSDK::Transport, write: nil),
+                          is_streaming_mode: true)
+    end
+
+    it 'raises ControlRequestTimeoutError on the reactor when no response arrives' do
+      Async do
+        expect { query.interrupt }
+          .to raise_error(ClaudeAgentSDK::ControlRequestTimeoutError, /interrupt/)
+      end.wait
+    end
+
+    it 'raises ControlRequestTimeoutError on a plain thread when no response arrives' do
+      thread = Thread.new do
+        Thread.current.report_on_exception = false
+        query.interrupt
+      end
+      expect { thread.join }
+        .to raise_error(ClaudeAgentSDK::ControlRequestTimeoutError, /interrupt/)
+    end
+  end
+
   describe 'control request task tracking' do
     it 'does not retain finished tasks for synchronously-handled control requests' do
       # async runs a non-suspending child to completion inside parent.async{},

--- a/spec/unit/query_spec.rb
+++ b/spec/unit/query_spec.rb
@@ -1215,6 +1215,30 @@ RSpec.describe ClaudeAgentSDK::Query do
     end
   end
 
+  describe 'control request task tracking' do
+    it 'does not retain finished tasks for synchronously-handled control requests' do
+      # async runs a non-suspending child to completion inside parent.async{},
+      # so the handler's ensure-delete fired BEFORE the read loop registered
+      # the task — every synchronously-handled request (MCP metadata,
+      # unsupported subtypes) leaked a finished Async::Task into the map.
+      messages = [
+        { type: 'control_request', request_id: 'req_sync_1', request: { subtype: 'not_a_real_subtype' } },
+        { type: 'control_request', request_id: 'req_sync_2', request: { subtype: 'not_a_real_subtype' } }
+      ]
+      transport = Class.new do
+        def initialize(messages) = (@messages = messages)
+        def read_messages(&block) = @messages.each(&block)
+        def write(_str) = nil
+        def close = nil
+      end.new(messages)
+      query = described_class.new(transport: transport, is_streaming_mode: true)
+
+      Async { query.send(:read_messages) }.wait
+
+      expect(query.instance_variable_get(:@inflight_control_request_tasks)).to be_empty
+    end
+  end
+
   describe 'transcript mirror wiring' do
     # Minimal transport that replays a fixed list of frames through read_messages.
     def fake_transport(messages)

--- a/spec/unit/require_surface_spec.rb
+++ b/spec/unit/require_surface_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'open3'
+require 'rbconfig'
+
+# Exercises the gem's require surface in a pristine child process: the spec
+# process has already loaded every file, so an in-process `require` cannot
+# detect a missing shim or a missing transitive require.
+RSpec.describe 'require surface' do
+  def run_ruby(code)
+    lib_dir = File.expand_path('../../lib', __dir__)
+    Open3.capture3(RbConfig.ruby, '-I', lib_dir, '-e', code)
+  end
+
+  it 'loads the full SDK via the gem-named require (the Bundler autorequire path)' do
+    # Bundler.require tries `require 'claude-agent-sdk'` then
+    # 'claude/agent/sdk' and silently swallows both LoadErrors, leaving the
+    # SDK unloaded in every default Rails/Bundler app unless this shim exists.
+    _out, err, status = run_ruby("require 'claude-agent-sdk'; exit(ClaudeAgentSDK.respond_to?(:query) ? 0 : 1)")
+    expect(status.exitstatus).to eq(0), "expected `require 'claude-agent-sdk'` to load the SDK: #{err}"
+  end
+end

--- a/spec/unit/require_surface_spec.rb
+++ b/spec/unit/require_surface_spec.rb
@@ -20,4 +20,15 @@ RSpec.describe 'require surface' do
     _out, err, status = run_ruby("require 'claude-agent-sdk'; exit(ClaudeAgentSDK.respond_to?(:query) ? 0 : 1)")
     expect(status.exitstatus).to eq(0), "expected `require 'claude-agent-sdk'` to load the SDK: #{err}"
   end
+
+  it 'loads the SDK core via the documented instrumentation entry point' do
+    # docs/rails.md's initializer and OTelObserver's own @example use
+    # `require 'claude_agent_sdk/instrumentation'` as their only require;
+    # it must pull in the core (configure, ClaudeAgentOptions, ...) too.
+    code = "require 'claude_agent_sdk/instrumentation'; " \
+           "ClaudeAgentSDK.configure { |c| c.default_options = {} }; " \
+           'exit(defined?(ClaudeAgentSDK::ClaudeAgentOptions) ? 0 : 1)'
+    _out, err, status = run_ruby(code)
+    expect(status.exitstatus).to eq(0), "instrumentation entry point must load the SDK core: #{err}"
+  end
 end

--- a/spec/unit/sdk_mcp_server_spec.rb
+++ b/spec/unit/sdk_mcp_server_spec.rb
@@ -643,3 +643,23 @@ RSpec.describe ClaudeAgentSDK, '.create_sdk_mcp_server' do
     expect(result[:content].first[:text]).to eq('15 + 27 = 42')
   end
 end
+
+RSpec.describe ClaudeAgentSDK, '.extract_sdk_mcp_servers' do
+  it 'extracts live instances from hash and typed sdk configs, ignoring other server types' do
+    server = Object.new
+    servers = described_class.extract_sdk_mcp_servers(
+      hash_sdk: { type: 'sdk', name: 'a', instance: server },
+      # A typed McpSdkServerConfig previously failed the Hash-only guard,
+      # so its in-process server was silently never registered.
+      typed_sdk: ClaudeAgentSDK::McpSdkServerConfig.new(name: 'b', instance: server),
+      http: ClaudeAgentSDK::McpHttpServerConfig.new(url: 'https://example.com/mcp'),
+      stdio: { type: 'stdio', command: 'node' }
+    )
+    expect(servers).to eq(hash_sdk: server, typed_sdk: server)
+  end
+
+  it 'returns an empty hash for non-Hash mcp_servers values' do
+    expect(described_class.extract_sdk_mcp_servers('path/to/config.json')).to eq({})
+    expect(described_class.extract_sdk_mcp_servers(nil)).to eq({})
+  end
+end

--- a/spec/unit/sdk_mcp_server_spec.rb
+++ b/spec/unit/sdk_mcp_server_spec.rb
@@ -642,6 +642,20 @@ RSpec.describe ClaudeAgentSDK, '.create_sdk_mcp_server' do
     result = server.call_tool('add', { a: 15, b: 27 })
     expect(result[:content].first[:text]).to eq('15 + 27 = 42')
   end
+
+  it 'makes a Symbol-named tool callable by its string wire name' do
+    # tools/call arrives from the CLI with the name as a JSON String; a
+    # Symbol name stored verbatim was advertised in tools/list but missed
+    # the gem's name-keyed lookup — 'Tool not found' on every invocation.
+    tool = described_class.create_tool(:greet, 'Greet', { who: :string }) do |args|
+      { content: [{ type: 'text', text: "hi #{args[:who]}" }] }
+    end
+    server = described_class.create_sdk_mcp_server(name: 'greeter', tools: [tool])[:instance]
+
+    expect(server.list_tools.first[:name]).to eq('greet')
+    result = server.call_tool('greet', { who: 'ruby' })
+    expect(result[:content].first[:text]).to eq('hi ruby')
+  end
 end
 
 RSpec.describe ClaudeAgentSDK, '.extract_sdk_mcp_servers' do

--- a/spec/unit/session_mutations_spec.rb
+++ b/spec/unit/session_mutations_spec.rb
@@ -231,6 +231,46 @@ RSpec.describe ClaudeAgentSDK::SessionMutations do
     end
   end
 
+  describe 'zero-byte stub fall-through' do
+    let(:user_uuid) { '44444444-4444-4444-4444-444444444444' }
+
+    # A 0-byte <sid>.jsonl stub in the primary project dir must not stop the
+    # file search when the real transcript lives under a worktree's project
+    # dir — the read path (Sessions.stat_candidate) and the append path
+    # already skip stubs. The mutation locator accepted them: delete_session
+    # removed the stub while the real data survived, and fork_session raised
+    # 'has no messages to fork' though a forkable transcript existed.
+    it 'forks and deletes the worktree transcript instead of stopping at a 0-byte stub' do
+      Dir.mktmpdir do |tmpdir|
+        main_path = File.join(tmpdir, 'main')
+        wt_path = File.join(tmpdir, 'wt')
+        FileUtils.mkdir_p(main_path)
+        FileUtils.mkdir_p(wt_path)
+        main_real = File.realpath(main_path).unicode_normalize(:nfc)
+        wt_real = File.realpath(wt_path).unicode_normalize(:nfc)
+        config = File.join(tmpdir, 'config')
+        main_proj = File.join(config, 'projects', ClaudeAgentSDK::Sessions.sanitize_path(main_real))
+        wt_proj = File.join(config, 'projects', ClaudeAgentSDK::Sessions.sanitize_path(wt_real))
+        FileUtils.mkdir_p(main_proj)
+        FileUtils.mkdir_p(wt_proj)
+        stub_file = File.join(main_proj, "#{session_id}.jsonl")
+        real_file = File.join(wt_proj, "#{session_id}.jsonl")
+        File.write(stub_file, '')
+        File.write(real_file,
+                   "{\"type\":\"user\",\"uuid\":\"#{user_uuid}\",\"parentUuid\":null,\"message\":{\"content\":\"hello\"}}\n")
+        allow(ClaudeAgentSDK::Sessions).to receive(:config_dir).and_return(config)
+        allow(ClaudeAgentSDK::Sessions).to receive(:detect_worktrees).and_return([wt_real])
+
+        fork = described_class.fork_session(session_id: session_id, directory: main_path)
+        expect(File.exist?(File.join(wt_proj, "#{fork.session_id}.jsonl"))).to be true
+
+        described_class.delete_session(session_id: session_id, directory: main_path)
+        expect(File.exist?(real_file)).to be false
+        expect(File.exist?(stub_file)).to be true
+      end
+    end
+  end
+
   describe '.fork_session' do
     let(:msg1_uuid) { '11111111-1111-1111-1111-111111111111' }
     let(:msg2_uuid) { '22222222-2222-2222-2222-222222222222' }

--- a/spec/unit/session_mutations_spec.rb
+++ b/spec/unit/session_mutations_spec.rb
@@ -3,6 +3,7 @@
 require 'spec_helper'
 require 'tmpdir'
 require 'json'
+require 'timeout'
 
 RSpec.describe ClaudeAgentSDK::SessionMutations do
   let(:session_id) { '550e8400-e29b-41d4-a716-446655440000' }
@@ -269,6 +270,26 @@ RSpec.describe ClaudeAgentSDK::SessionMutations do
         expect do
           described_class.fork_session(session_id: session_id, directory: tmpdir)
         end.not_to raise_error
+      end
+    end
+
+    it 'terminates on a progress-entry parentUuid cycle instead of hanging' do
+      # resolve_parent_uuid walks the chain skipping progress entries; without
+      # a visited set, a cycle among progress entries (corrupt/malformed
+      # transcript) spun forever — every other chain walker guards this.
+      Dir.mktmpdir do |tmpdir|
+        content = build_session_content([
+                                          { 'type' => 'progress', 'uuid' => 'p1', 'parentUuid' => 'p2' },
+                                          { 'type' => 'progress', 'uuid' => 'p2', 'parentUuid' => 'p1' },
+                                          { 'type' => 'user', 'uuid' => msg1_uuid, 'parentUuid' => 'p1',
+                                            'message' => { 'content' => 'hello' } }
+                                        ])
+        setup_session(tmpdir, content)
+
+        result = Timeout.timeout(5) do
+          described_class.fork_session(session_id: session_id, directory: tmpdir)
+        end
+        expect(result.session_id).to match(ClaudeAgentSDK::Sessions::UUID_RE)
       end
     end
 

--- a/spec/unit/subprocess_cli_transport_spec.rb
+++ b/spec/unit/subprocess_cli_transport_spec.rb
@@ -964,6 +964,43 @@ RSpec.describe ClaudeAgentSDK::SubprocessCLITransport do
     end
   end
 
+  describe '#read_messages — invalid UTF-8 robustness' do
+    let(:options) { ClaudeAgentSDK::ClaudeAgentOptions.new(cli_path: '/usr/bin/claude') }
+    let(:transport) { described_class.new('hi', options) }
+
+    def wire_stdout(text)
+      fake_process = instance_double(Process::Waiter, value: instance_double(Process::Status, exitstatus: 0))
+      transport.instance_variable_set(:@stdout, StringIO.new(text))
+      transport.instance_variable_set(:@process, fake_process)
+    end
+
+    # Regression: stdout is UTF-8-tagged, so a single line carrying invalid
+    # bytes made line.strip raise Encoding::CompatibilityError, aborting the
+    # stream and dropping every already-buffered valid frame (including a
+    # trailing result). The version-probe path already scrubbed; the read
+    # loop must too.
+    it 'survives a stray line with invalid UTF-8 bytes and keeps delivering later frames' do
+      wire_stdout(
+        "{\"type\":\"system\",\"subtype\":\"init\"}\n" \
+        "stray \xFF binary noise\n" \
+        "{\"type\":\"result\",\"subtype\":\"success\"}\n"
+      )
+      messages = []
+      transport.read_messages { |m| messages << m }
+
+      expect(messages.map { |m| m[:type] }).to eq(%w[system result])
+    end
+
+    it 'scrubs invalid bytes inside a JSON frame instead of raising mid-stream' do
+      wire_stdout("{\"type\":\"system\",\"note\":\"caf\xE9\"}\n")
+      messages = []
+      transport.read_messages { |m| messages << m }
+
+      expect(messages.length).to eq(1)
+      expect(messages.first[:note]).to start_with('caf')
+    end
+  end
+
   describe '#write — close-while-writing does not deadlock' do
     let(:options) { ClaudeAgentSDK::ClaudeAgentOptions.new(cli_path: '/usr/bin/claude') }
     let(:transport) { described_class.new('hi', options) }


### PR DESCRIPTION
## Summary

First fix batch from the 2026-07-03 full-codebase audit (report: `AUDIT-2026-07-03.md`, committed here). All 11 items are **Batch A — zero-risk**: pure additions and guards that change behavior only for inputs that previously produced silent breakage, wrong results, hangs, or crashes.

| Audit ID | Fix | Commit |
|---|---|---|
| **H1** | `lib/claude-agent-sdk.rb` shim — `Bundler.require` silently skipped the SDK in every default Rails/Bundler app (NameError at first use) | 0b7aca7 |
| **M9** | `require 'claude_agent_sdk/instrumentation'` now loads the SDK core (docs/rails.md initializer and otel.rb's `@example` crashed) | dd6ca52 |
| **M17** | Typed `Mcp*ServerConfig` objects serialize via their wire hash instead of `#<...>` garbage; `McpSdkServerConfig` instances now actually register their in-process server (new `extract_sdk_mcp_servers` helper) | 6dfefa7 |
| **L4** | `create_tool(:name, ...)` — Symbol names were advertised but uncallable ('Tool not found' on every invocation) | d069670 |
| **M1** | Synchronously-handled control requests (SDK-MCP metadata, unsupported subtypes) leaked one finished `Async::Task` each into `@inflight_control_request_tasks`, forever | 5a45cfa |
| **M3** | One invalid-UTF-8 stdout line aborted the whole stream and dropped buffered valid frames (incl. trailing `result`); now scrubbed like the version-probe path | ab7169c |
| **M10** | `fork_session` hung forever on a progress-entry `parentUuid` cycle (only chain walker without a visited set) | f3a2f08 |
| **M11** | `fork_session`/`delete_session` stopped at 0-byte stubs instead of falling through to the worktree holding the real transcript (mutations now mirror `stat_candidate`) | 0e65024 |
| **I2** | `observers: [SomeClass]` (class instead of instance) produced silent zero instrumentation; now warned about and skipped | 575c0c5 |
| **I3** | Both `ControlRequestTimeoutError` paths (reactor + worker-thread deadline loop) had zero spec coverage — test-only | 4d51109 |
| **I4** | `spec.files` from `git ls-files` (byte-identical on a clean tree) instead of a working-tree `Dir` glob that shipped stray untracked files | b931325 |

## Verification

- Every fix landed **test-first**: each regression spec was confirmed red on the unfixed code, then green after (independently re-confirmed by the adversarial review below against an archived copy of main's `lib/`).
- Full suite: **1026 examples, 0 failures** (was 1010); RuboCop clean.
- Adversarial (critic) review of the whole diff explicitly attacked: M1 registration races (none — no suspension point between check and insert), M3 multibyte chars straddling over-limit chunks (verified `each_line` never splits a valid char, so valid input is never scrubbed), circular requires from M9 (none), Type-coercion collateral for M17 (none — `nil`/Hash/String configs untouched), gemspec behavior under worktrees, shallow clones (the `publish.yml` shape), missing git, and tarballs (all correct, incl. fallback), Ruby 3.2 compat (`Set` autoload, `filter_map`, `scrub`, `IO.popen` opts).

## Deliberate behavior tightenings (for the next CHANGELOG)

- `delete_session`/`fork_session` on a session whose **only** copy is a 0-byte stub now raise `Errno::ENOENT` (consistent with the read paths, which already hide such sessions; ENOENT was already in the documented raise list).
- Observers implementing the interface only via bare `method_missing` (no `respond_to_missing?`) are now skipped **with a warning**; proper proxies survive.
- `gem build` from a dirty tree with index-tracked-but-deleted files now fails fast instead of silently packaging what happened to be on disk.

Batches B–D from the audit report remain open (see `AUDIT-2026-07-03.md` §6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKV9BaVrqfaspkc4TifrXA