### PR TITLE
Add advisor_model option for the server-side advisor tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ options = ClaudeAgentSDK::ClaudeAgentOptions.new(
 
 | Topic | Reference |
 |-------|-----------|
-| Structured output, thinking config, budget, fallback model, beta features, sandbox, bare mode, file checkpointing | [docs/configuration.md](docs/configuration.md) |
+| Structured output, thinking config, budget, fallback model, advisor model, beta features, sandbox, bare mode, file checkpointing | [docs/configuration.md](docs/configuration.md) |
 | Session listing, reading, renaming, tagging, deleting, forking, resume-at-message | [docs/sessions.md](docs/sessions.md) |
 | OpenTelemetry tracing, Langfuse setup, custom observers | [docs/observability.md](docs/observability.md) |
 | Rails integration (fiber safety, ActionCable, sessions, jobs, HTTP MCP, observability initializer) | [docs/rails.md](docs/rails.md) |
@@ -253,6 +253,7 @@ options = ClaudeAgentSDK::ClaudeAgentOptions.new(
 |---------|-------------|
 | [budget_control_example.rb](https://github.com/ya-luotao/claude-agent-sdk-ruby/blob/main/examples/budget_control_example.rb) | Budget control with `max_budget_usd` |
 | [fallback_model_example.rb](https://github.com/ya-luotao/claude-agent-sdk-ruby/blob/main/examples/fallback_model_example.rb) | Fallback model configuration |
+| [advisor_example.rb](https://github.com/ya-luotao/claude-agent-sdk-ruby/blob/main/examples/advisor_example.rb) | Server-side advisor tool (`advisor_model`) |
 | [extended_thinking_example.rb](https://github.com/ya-luotao/claude-agent-sdk-ruby/blob/main/examples/extended_thinking_example.rb) | Extended thinking |
 | [e2b_transport_example.rb](https://github.com/ya-luotao/claude-agent-sdk-ruby/blob/main/examples/e2b_transport_example.rb) | Custom transport running CLI in an E2B microVM |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,6 +104,41 @@ options = ClaudeAgentSDK::ClaudeAgentOptions.new(
 
 See [examples/fallback_model_example.rb](https://github.com/ya-luotao/claude-agent-sdk-ruby/blob/main/examples/fallback_model_example.rb).
 
+## Advisor Model
+
+Pair the main model with a stronger advisor model that Claude consults at key
+decision points (before committing to an approach, when stuck on a recurring
+error, before declaring a task done). The advisor runs server-side and
+receives the full conversation.
+
+```ruby
+options = ClaudeAgentSDK::ClaudeAgentOptions.new(
+  model: 'haiku',
+  advisor_model: 'opus'  # alias or full model ID, e.g. 'claude-opus-4-8'
+)
+```
+
+Advisor consultations surface in `AssistantMessage` content as
+`ServerToolUseBlock` (name `'advisor'`) and `ServerToolResultBlock`
+(`advisor_tool_result`) blocks.
+
+Notes:
+
+- Experimental; requires the Anthropic API (not available on Bedrock, Google
+  Cloud's Agent Platform, or Microsoft Foundry). Requires Claude Code CLI with
+  advisor support (v2.1.x).
+- The CLI validates the pairing — the advisor must be at least as capable as
+  the main model (e.g. a Haiku main accepts an Opus advisor; the reverse is
+  rejected). Pairing rules are CLI-version-dependent, so the SDK passes the
+  value through without validating it.
+- Advisor calls are billed at the advisor model's rates in addition to the
+  main model's usage.
+- `CLAUDE_CODE_DISABLE_ADVISOR_TOOL=1` (settable via `options.env`) disables
+  the advisor tool entirely; a configured `advisor_model` is then ignored.
+
+See [examples/advisor_example.rb](https://github.com/ya-luotao/claude-agent-sdk-ruby/blob/main/examples/advisor_example.rb) and the
+[advisor documentation](https://code.claude.com/docs/en/advisor).
+
 ## Beta Features
 
 ```ruby

--- a/examples/advisor_example.rb
+++ b/examples/advisor_example.rb
@@ -1,0 +1,95 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'claude_agent_sdk'
+require 'async'
+
+# Example: Pairing the main model with a stronger advisor model.
+#
+# The advisor tool lets Claude consult a second, typically stronger model at
+# key decision points — before committing to an approach, when stuck on a
+# recurring error, or before declaring a task complete. The advisor receives
+# the full conversation and returns guidance that Claude applies before
+# continuing.
+#
+# Notes:
+# - Experimental; requires the Anthropic API (not available on Bedrock,
+#   Google Cloud's Agent Platform, or Microsoft Foundry).
+# - The CLI validates the model pairing: the advisor must be at least as
+#   capable as the main model (e.g. a Haiku main accepts an Opus advisor,
+#   but an Opus main rejects a Haiku advisor).
+# - Advisor calls are billed at the advisor model's rates on top of the
+#   main model's usage.
+#
+# Docs: https://code.claude.com/docs/en/advisor
+
+puts "=== Advisor Example ==="
+
+# Example 1: Haiku main model escalating decisions to an Opus advisor
+puts "\n--- Example 1: Haiku main + Opus advisor ---"
+
+options = ClaudeAgentSDK::ClaudeAgentOptions.new(
+  model: 'haiku',
+  advisor_model: 'opus', # alias or full model ID, e.g. 'claude-opus-4-8'
+  allowed_tools: ['Read', 'Glob'],
+  max_turns: 5
+)
+
+ClaudeAgentSDK.query(
+  prompt: 'Consult the advisor about the best one-sentence description of this project, then answer.',
+  options: options
+) do |message|
+  case message
+  when ClaudeAgentSDK::AssistantMessage
+    message.content.each do |block|
+      case block
+      when ClaudeAgentSDK::TextBlock
+        puts block.text
+      when ClaudeAgentSDK::ServerToolUseBlock
+        # The advisor runs server-side; its invocation appears as a
+        # server_tool_use block named 'advisor'.
+        puts "[advisor consulted: #{block.name}]" if block.name == 'advisor'
+      when ClaudeAgentSDK::ServerToolResultBlock
+        # The advisor's guidance comes back as an advisor_tool_result block.
+        puts "[advisor result received]"
+      end
+    end
+  when ClaudeAgentSDK::ResultMessage
+    puts "\nCost: $#{message.total_cost_usd}" if message.total_cost_usd
+  end
+end
+
+puts "\n#{'=' * 50}"
+
+# Example 2: Client session with an advisor configured
+puts "\n--- Example 2: Client session with advisor ---"
+
+Async do
+  client = ClaudeAgentSDK::Client.new(
+    options: ClaudeAgentSDK::ClaudeAgentOptions.new(
+      model: 'sonnet',
+      advisor_model: 'opus'
+    )
+  )
+
+  begin
+    client.connect
+    client.query('Before answering, consult the advisor: what is the riskiest part of parsing untrusted JSON?')
+
+    client.receive_response do |msg|
+      case msg
+      when ClaudeAgentSDK::AssistantMessage
+        msg.content.each do |block|
+          puts block.text if block.is_a?(ClaudeAgentSDK::TextBlock)
+        end
+      when ClaudeAgentSDK::ResultMessage
+        puts "\nCost: $#{msg.total_cost_usd}" if msg.total_cost_usd
+      end
+    end
+  ensure
+    client.disconnect
+  end
+end.wait
+
+puts "\nDone!"

--- a/lib/claude_agent_sdk/command_builder.rb
+++ b/lib/claude_agent_sdk/command_builder.rb
@@ -124,6 +124,10 @@ module ClaudeAgentSDK
     def append_model(cmd)
       cmd.push("--model", @options.model) if @options.model
       cmd.push("--fallback-model", @options.fallback_model) if @options.fallback_model
+      # Server-side advisor tool (experimental, Anthropic API only). The CLI
+      # validates the main-model/advisor pairing; pairing rules are
+      # CLI-version-dependent, so the SDK passes the value through verbatim.
+      cmd.push("--advisor", @options.advisor_model) if @options.advisor_model
     end
 
     def append_permission(cmd)

--- a/lib/claude_agent_sdk/types.rb
+++ b/lib/claude_agent_sdk/types.rb
@@ -1553,7 +1553,7 @@ module ClaudeAgentSDK
                   :can_use_tool, :hooks, :user,
                   :agents, :setting_sources, :skills,
                   :output_format, :max_budget_usd, :max_thinking_tokens,
-                  :fallback_model, :plugins, :debug_stderr,
+                  :fallback_model, :advisor_model, :plugins, :debug_stderr,
                   :betas, :tools, :sandbox,
                   :thinking, :effort, :observers, :task_budget,
                   :session_store, :session_store_flush, :load_timeout_ms

--- a/spec/unit/command_builder_spec.rb
+++ b/spec/unit/command_builder_spec.rb
@@ -571,6 +571,26 @@ RSpec.describe ClaudeAgentSDK::CommandBuilder do
     end
   end
 
+  describe 'advisor model' do
+    it 'passes --advisor with the configured model' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(advisor_model: 'opus')
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--advisor', 'opus')
+    end
+
+    it 'passes a full model ID verbatim alongside --model' do
+      options = ClaudeAgentSDK::ClaudeAgentOptions.new(model: 'claude-haiku-4-5', advisor_model: 'claude-opus-4-8')
+      cmd = described_class.new('/usr/bin/claude', options).build
+      expect(cmd).to include('--model', 'claude-haiku-4-5')
+      expect(cmd).to include('--advisor', 'claude-opus-4-8')
+    end
+
+    it 'omits --advisor by default' do
+      cmd = described_class.new('/usr/bin/claude', ClaudeAgentSDK::ClaudeAgentOptions.new).build
+      expect(cmd).not_to include('--advisor')
+    end
+  end
+
   describe 'mutually exclusive session flags' do
     it 'raises ArgumentError when both continue_conversation and resume are set' do
       options = ClaudeAgentSDK::ClaudeAgentOptions.new(

--- a/spec/unit/types_spec.rb
+++ b/spec/unit/types_spec.rb
@@ -705,6 +705,7 @@ RSpec.describe ClaudeAgentSDK do
         expect(options.max_budget_usd).to be_nil
         expect(options.max_thinking_tokens).to be_nil
         expect(options.fallback_model).to be_nil
+        expect(options.advisor_model).to be_nil
         expect(options.plugins).to be_nil
         expect(options.debug_stderr).to be_nil
         expect(options.session_store).to be_nil
@@ -756,6 +757,7 @@ RSpec.describe ClaudeAgentSDK do
           max_budget_usd: 10.0,
           max_thinking_tokens: 5000,
           fallback_model: 'claude-haiku-3',
+          advisor_model: 'opus',
           plugins: [plugin],
           debug_stderr: '/tmp/debug.log'
         )
@@ -764,6 +766,7 @@ RSpec.describe ClaudeAgentSDK do
         expect(options.max_budget_usd).to eq(10.0)
         expect(options.max_thinking_tokens).to eq(5000)
         expect(options.fallback_model).to eq('claude-haiku-3')
+        expect(options.advisor_model).to eq('opus')
         expect(options.plugins).to eq([plugin])
         expect(options.debug_stderr).to eq('/tmp/debug.log')
       end


### PR DESCRIPTION
## Summary

Adds first-class SDK support for Claude Code's experimental [advisor tool](https://code.claude.com/docs/en/advisor), which pairs the main model with a stronger advisor model that Claude consults at key decision points.

- `ClaudeAgentOptions.advisor_model` — accepts a model alias (`'opus'`) or full model ID (`'claude-opus-4-8'`)
- `CommandBuilder` emits it as the CLI's `--advisor <model>` flag
- Message-parsing support already existed: consultations surface as `ServerToolUseBlock` (name `'advisor'`) and `ServerToolResultBlock` (`advisor_tool_result`) content blocks

The CLI validates the main-model/advisor pairing (rules are CLI-version-dependent), so the SDK deliberately passes the value through verbatim — same approach as `model`/`fallback_model`.

Note: this is ahead of the Python SDK, which currently only parses the advisor result blocks and exposes no advisor option.

## Changes

- `lib/claude_agent_sdk/types.rb` — new `advisor_model` field on `ClaudeAgentOptions`
- `lib/claude_agent_sdk/command_builder.rb` — `--advisor` flag in `append_model`
- `spec/unit/command_builder_spec.rb` / `spec/unit/types_spec.rb` — flag emission/omission + option default/assignment tests
- `examples/advisor_example.rb` — `query()` and `Client` usage, including observing advisor blocks
- `docs/configuration.md` — new "Advisor Model" section (requirements, pairing rules, billing, `CLAUDE_CODE_DISABLE_ADVISOR_TOOL`)
- `README.md` — example row + advanced-topics mention

## Verification

- `bundle exec rspec` — 1080 examples, 0 failures
- `bundle exec rubocop` — no offenses
- End-to-end against CLI 2.1.207:
  - invalid advisor model → CLI pairing error surfaces as `ProcessError` ("The model \"…\" cannot be used as an advisor")
  - `model: 'haiku', advisor_model: 'opus'` real query → advisor `server_tool_use` + `advisor_tool_result` blocks observed, result `is_error=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BVsxLmnLjsTCsgr4UhEeCd