### PR TITLE
Sync with Python SDK v0.2.134: validate skill names in ClaudeAgentOptions#skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Skill names in `ClaudeAgentOptions#skills` are now validated** (port of Python SDK [#1145](https://github.com/anthropics/claude-agent-sdk-python/pull/1145), v0.2.129). Names were formatted into the `--allowedTools` value unchecked; the CLI splits that value into permission rules on commas and spaces outside parentheses with no escape sequences, so a name carrying a delimiter could not be passed through reliably. The command builder now validates each name and fails closed with `ArgumentError` (`TypeError` for non-String entries). Rejected: parentheses, commas, control characters (C0, DEL, C1), U+FEFF, empty names; a literal `*` and wildcard suffixes (`:*`, ` *`); and shapes that parse but can never match the listed skill — surrounding whitespace (Unicode-aware, unlike `String#strip`), a leading `/`, consecutive backslashes, a trailing unpaired backslash, and byte sequences that cannot form valid UTF-8 (Ruby's analogue of Python's surrogate check). Ordinary names are unaffected, including plugin-qualified names, interior spaces, single backslashes, and non-ASCII; valid non-UTF-8 strings are converted so the argv join cannot raise `Encoding::CompatibilityError`.
+  - **Breaking:** `skills: ['*']` and `skills: ['plugin:*']` now raise — use `skills: 'all'`, or a `Skill(...)` rule in `allowed_tools` for prefix matching. `skills: [' name']` and `skills: ['/name']` now raise as well; both previously built a rule that could never match, so the skill was silently unavailable.
+
 ## [0.28.0] - 2026-07-31
 
 ### Changed

--- a/lib/claude_agent_sdk/command_builder.rb
+++ b/lib/claude_agent_sdk/command_builder.rb
@@ -9,6 +9,16 @@ module ClaudeAgentSDK
   class CommandBuilder
     EXTRA_ARG_FLAG_REGEXP = /\A[a-z0-9][a-z0-9-]*\z/
 
+    # Parentheses and commas are delimiters to the --allowedTools tokenizer;
+    # control characters (C0, DEL, C1) never appear in a skill directory name.
+    # U+FEFF is here rather than in the whitespace checks below because the
+    # CLI trims it as whitespace and [[:space:]] does not match it.
+    SKILL_NAME_INVALID_CHARS = /[(),\u0000-\u001F\u007F-\u009F\uFEFF]/
+
+    # Unicode-aware edge whitespace: the CLI and Skill tool trim Unicode
+    # whitespace, and Ruby's String#strip is ASCII-only.
+    SKILL_NAME_EDGE_WHITESPACE = /\A[[:space:]]+|[[:space:]]+\z/
+
     def initialize(cli_path, options)
       @cli_path = cli_path
       @options = options
@@ -93,24 +103,87 @@ module ClaudeAgentSDK
     # entry, no duplicates) and default setting_sources to user+project so
     # skill files are actually discovered. Explicit setting_sources (including
     # []) is never overridden. Non-mutating; returns the effective pair.
-    # Justified divergence: a non-'all' String raises (NoMethodError on #each)
-    # instead of Python's quirk of iterating its characters.
+    # Each listed name is validated before being formatted into a rule (see
+    # #validate_skill_name). Both SDKs reject non-list, non-'all' shapes
+    # loudly; this raises ArgumentError where Python raises TypeError.
     def skills_defaults
       allowed_tools = @options.allowed_tools.dup
       setting_sources = @options.setting_sources&.dup
       skills = @options.skills
       return [allowed_tools, setting_sources] if skills.nil?
 
-      # Fail loudly with a clear message instead of a bare NoMethodError from
-      # deep inside build for skills: :all / 'pdf' / Hash typos (and instead
-      # of Python's quirk of iterating a String's characters).
       valid = skills == "all" || skills.is_a?(Array)
       raise ArgumentError, "skills must be 'all' or an Array of skill names (got #{skills.inspect})" unless valid
 
-      entries = skills == "all" ? ["Skill"] : skills.map { |name| "Skill(#{name})" }
+      entries = skills == "all" ? ["Skill"] : skills.map { |name| "Skill(#{validate_skill_name(name)})" }
       entries.each { |entry| allowed_tools << entry unless allowed_tools.include?(entry) }
       setting_sources = %w[user project] if setting_sources.nil?
       [allowed_tools, setting_sources]
+    end
+
+    # Reject skill names that cannot ride safely in a Skill(name) rule
+    # (port of Python SDK #1145). Names from options.skills are formatted
+    # into the --allowedTools value, which the CLI splits into rules on
+    # commas and spaces outside parentheses. That tokenizer honors no escape
+    # sequences -- escaping exists only in the per-rule grammar, applied
+    # after splitting -- so a name carrying a delimiter cannot be passed
+    # through reliably: what it tokenizes into depends on what surrounds it.
+    #
+    # Names that tokenize cleanly but can never match the listed skill are
+    # rejected too, so a dead rule fails loudly here instead of silently
+    # granting nothing. Returns the name as a UTF-8 String so later argv
+    # joins cannot raise Encoding::CompatibilityError.
+    def validate_skill_name(name) # rubocop:disable Metrics/MethodLength
+      raise TypeError, "Skill names must be strings, got #{name.class}: #{name.inspect}" unless name.is_a?(String)
+
+      # Ruby's analogue of Python's surrogate check: a lone surrogate (or any
+      # other broken byte sequence) is unrepresentable in valid UTF-8, and no
+      # CLI-discovered skill name contains one.
+      utf8 = begin
+        name.encode(Encoding::UTF_8)
+      rescue EncodingError
+        nil
+      end
+      if utf8.nil? || !utf8.valid_encoding?
+        raise ArgumentError, "Invalid skill name #{name.inspect}: contains bytes that cannot form " \
+                             "valid UTF-8 (such as a surrogate code point), which can never match " \
+                             "a skill the CLI discovered."
+      end
+
+      stripped = utf8.gsub(SKILL_NAME_EDGE_WHITESPACE, "")
+      raise ArgumentError, "Skill names must be non-empty strings" if stripped.empty?
+
+      if utf8 != stripped
+        raise ArgumentError, "Invalid skill name #{name.inspect}: leading or trailing whitespace " \
+                             "can never match -- the Skill tool trims the invoked name."
+      end
+      if SKILL_NAME_INVALID_CHARS.match?(utf8)
+        raise ArgumentError, "Invalid skill name #{name.inspect}: parentheses, commas, control " \
+                             "characters, and byte-order marks are not allowed. Names match the " \
+                             "skill's directory name, or 'plugin:skill' for plugin-qualified skills."
+      end
+      raise ArgumentError, "Invalid skill name '*': use skills: 'all' to enable every skill." if utf8 == "*"
+
+      if utf8.end_with?(":*", " *")
+        raise ArgumentError, "Invalid skill name #{name.inspect}: wildcard-suffix names are not " \
+                             "allowed; list each skill by its exact name."
+      end
+      if utf8.start_with?("/")
+        raise ArgumentError, "Invalid skill name #{name.inspect}: skill names may not start with " \
+                             "'/'. The skills option takes the canonical name, not the " \
+                             "slash-command form."
+      end
+      if utf8.include?("\\\\")
+        raise ArgumentError, "Invalid skill name #{name.inspect}: consecutive backslashes are not " \
+                             "allowed -- the per-rule parser collapses them, so the rule would " \
+                             "name a different skill."
+      end
+      if utf8.end_with?("\\")
+        raise ArgumentError, "Invalid skill name #{name.inspect}: names may not end with an " \
+                             "unpaired backslash."
+      end
+
+      utf8
     end
 
     def append_disallowed_tools(cmd)

--- a/spec/unit/command_builder_spec.rb
+++ b/spec/unit/command_builder_spec.rb
@@ -156,6 +156,116 @@ RSpec.describe ClaudeAgentSDK::CommandBuilder do
       expect(flag_value(cmd, '--allowedTools')).to eq('Read')
       expect(cmd).not_to include('--setting-sources')
     end
+
+    describe 'skill name validation (port of Python SDK #1145)' do
+      def expect_rejects(name, error_class, message_re)
+        options = ClaudeAgentSDK::ClaudeAgentOptions.new(skills: [name])
+        expect { build(options) }.to raise_error(error_class, message_re)
+      end
+
+      it 'rejects names containing rule-syntax delimiters' do
+        ['x),Bash(*', 'safe),Bash,Skill(dummy', 'name,with,commas', 'unbalanced(', 'unbalanced)', '()'].each do |bad|
+          expect_rejects(bad, ArgumentError, /Invalid skill name/)
+        end
+      end
+
+      it 'rejects names containing C0 control characters and DEL' do
+        newline = 10.chr
+        tab = 9.chr
+        nul = 0.chr
+        del = 0x7F.chr
+        ["with#{newline}newline", "with#{tab}tab", "nul#{nul}byte", "del#{del}char"].each do |bad|
+          expect_rejects(bad, ArgumentError, /Invalid skill name/)
+        end
+      end
+
+      it 'rejects names containing C1 control characters' do
+        nel = 0x85.chr(Encoding::UTF_8)
+        csi = 0x9B.chr(Encoding::UTF_8)
+        ["nel#{nel}end", "csi#{csi}end"].each do |bad|
+          expect_rejects(bad, ArgumentError, /Invalid skill name/)
+        end
+      end
+
+      it 'rejects byte-order marks (the CLI trims U+FEFF as whitespace)' do
+        bom = 0xFEFF.chr(Encoding::UTF_8)
+        ["#{bom}pdf", "pdf#{bom}"].each do |bad|
+          expect_rejects(bad, ArgumentError, /Invalid skill name/)
+        end
+      end
+
+      it 'rejects empty or whitespace-only names' do
+        tab = 9.chr
+        ['', ' ', "  #{tab} "].each do |bad|
+          expect_rejects(bad, ArgumentError, /non-empty/)
+        end
+      end
+
+      it 'rejects non-string entries with TypeError' do
+        expect_rejects(42, TypeError, /must be strings/)
+      end
+
+      it 'rejects wildcard-suffix names' do
+        ['pdf:*', 'my skill *', ':*'].each do |bad|
+          expect_rejects(bad, ArgumentError, /wildcard-suffix/)
+        end
+      end
+
+      it "rejects a bare '*', pointing at skills: 'all'" do
+        expect_rejects('*', ArgumentError, /use skills: 'all'/)
+      end
+
+      it 'rejects surrounding whitespace (a padded rule can never match)' do
+        tab = 9.chr
+        [' pdf', 'pdf ', "#{tab}pdf", ' pdf '].each do |bad|
+          expect_rejects(bad, ArgumentError, /whitespace/)
+        end
+      end
+
+      it 'rejects non-ASCII surrounding whitespace (NBSP), unlike String#strip' do
+        nbsp = 0xA0.chr(Encoding::UTF_8)
+        expect_rejects("#{nbsp}pdf", ArgumentError, /whitespace/)
+      end
+
+      it 'rejects a leading slash (the session allowlist matches verbatim)' do
+        ['/pdf', '/myplugin:pdf'].each do |bad|
+          expect_rejects(bad, ArgumentError, /may not start with/)
+        end
+      end
+
+      it 'rejects an unpaired trailing backslash' do
+        expect_rejects('name\\', ArgumentError, /unpaired backslash/)
+      end
+
+      it 'rejects consecutive backslashes (the per-rule parser collapses them)' do
+        ['name\\\\', 'name\\\\\\', 'mid\\\\dle'].each do |bad|
+          expect_rejects(bad, ArgumentError, /consecutive backslashes/)
+        end
+      end
+
+      it 'rejects surrogate code points and other invalid byte sequences' do
+        lone_surrogate = ('lone'.b + [0xED, 0xA0, 0x80].pack('C*')).force_encoding(Encoding::UTF_8)
+        binary_high_bytes = 0xFF.chr
+        [lone_surrogate, binary_high_bytes].each do |bad|
+          expect_rejects(bad, ArgumentError, /valid UTF-8/)
+        end
+      end
+
+      it 'converts valid non-UTF-8 names so the argv join cannot raise' do
+        utf16 = 'pdf'.encode(Encoding::UTF_16LE)
+        cmd = build(ClaudeAgentSDK::ClaudeAgentOptions.new(skills: [utf16]))
+
+        expect(flag_value(cmd, '--allowedTools')).to eq('Skill(pdf)')
+      end
+
+      it 'accepts ordinary names, including plugin-qualified, spaced, and non-ASCII' do
+        ['pdf-tools', 'my_skill.v2', 'myplugin:pdf', 'skill with spaces', 'dir\\sub', '日本語スキル'].each do |good|
+          cmd = build(ClaudeAgentSDK::ClaudeAgentOptions.new(skills: [good]))
+
+          expect(flag_value(cmd, '--allowedTools')).to eq("Skill(#{good})")
+        end
+      end
+    end
   end
 
   describe 'Hash-form thinking config' do


### PR DESCRIPTION
## Summary

Brings the Ruby SDK to parity with Python SDK v0.2.134.

### Ported: anthropics/claude-agent-sdk-python#1145 — validate skill names in `ClaudeAgentOptions.skills` (v0.2.129)

Skill names from `skills: [...]` were formatted into the `--allowedTools` value unchecked. The CLI splits that value into permission rules on commas and spaces outside parentheses, and its tokenizer honors no escape sequences, so a name carrying one of those delimiters cannot be passed through reliably. `CommandBuilder#skills_defaults` now validates each name and fails closed.

**Rejected:** parentheses, commas, control characters (C0, DEL, C1), U+FEFF, empty names; a literal `*` and wildcard suffixes (`:*`, ` *`); and shapes that parse but can never match the listed skill — surrounding whitespace, a leading `/`, consecutive backslashes, a trailing unpaired backslash, and byte sequences that cannot form valid UTF-8.

**Unaffected:** ordinary names, including plugin-qualified names, interior spaces, single backslashes, and non-ASCII.

**Breaking:** `skills: ['*']` and `skills: ['plugin:*']` now raise — use `skills: 'all'`, or a `Skill(...)` rule in `allowed_tools` for prefix matching. `skills: [' name']` and `skills: ['/name']` now raise as well; both previously built a rule that could never match, so the skill was silently unavailable.

### Ruby adaptations

- Python `ValueError` → `ArgumentError`; `TypeError` kept for non-String entries. The existing `ArgumentError` for non-Array/non-`'all'` shapes is unchanged (Python's tuple/set/generator/bare-string cases collapse into that one check in Ruby).
- Python's surrogate check becomes an invalid-UTF-8 check: a lone surrogate is unrepresentable in valid UTF-8. Valid non-UTF-8 names (e.g. UTF-16) are converted so the later argv `join(",")` cannot raise `Encoding::CompatibilityError`.
- Edge-whitespace checks use `[[:space:]]` (Unicode-aware) since Ruby's `String#strip` is ASCII-only — `" pdf"` rejects like Python.

### Not applicable from v0.2.129–v0.2.134

All remaining upstream commits are bundled-CLI version bumps (2.1.221 → 2.1.226) and changelog updates; the Ruby gem does not bundle the CLI.

## Test plan

- Ported the upstream parametrized rejection/acceptance cases to `spec/unit/command_builder_spec.rb` (16 new examples), plus Ruby-specific cases: NBSP edge whitespace, invalid byte sequences, UTF-16 name conversion.
- `bundle exec rspec` — 1226 examples, 0 failures. `bundle exec rubocop` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS6ALBqEGJc3rGqNjnXGqD